### PR TITLE
Handle old per-world-settings config; typo: occured -> occuRRed

### DIFF
--- a/src/me/neznamy/tab/platforms/bukkit/Injector.java
+++ b/src/me/neznamy/tab/platforms/bukkit/Injector.java
@@ -70,7 +70,7 @@ public class Injector {
 						}
 					}
 				} catch (Throwable e){
-					Shared.error(null, "An error occured when reading packets", e);
+					Shared.error(null, "An error occurred when reading packets", e);
 				}
 				super.channelRead(context, packet);
 			}
@@ -154,7 +154,7 @@ public class Injector {
 						Shared.featureCPU(Feature.PLAYERLIST_2, System.nanoTime()-time);
 					}
 				} catch (Throwable e){
-					Shared.error(null, "An error occured when reading packets", e);
+					Shared.error(null, "An error occurred when reading packets", e);
 				}
 				super.write(context, packet, channelPromise);
 			}

--- a/src/me/neznamy/tab/platforms/bukkit/Injector1_7.java
+++ b/src/me/neznamy/tab/platforms/bukkit/Injector1_7.java
@@ -43,7 +43,7 @@ public class Injector1_7 {
 					}
 					Shared.featureCPU(Feature.NAMETAGAO, System.nanoTime()-time);
 				} catch (Throwable e){
-					Shared.error(null, "An error occured when reading packets", e);
+					Shared.error(null, "An error occurred when reading packets", e);
 				}
 				super.write(context, packet, channelPromise);
 			}

--- a/src/me/neznamy/tab/platforms/bukkit/Main.java
+++ b/src/me/neznamy/tab/platforms/bukkit/Main.java
@@ -159,7 +159,7 @@ public class Main extends JavaPlugin implements Listener, MainClass{
 				}
 			});
 		} catch (Throwable ex) {
-			Shared.error(null, "An error occured when player joined the server", ex);
+			Shared.error(null, "An error occurred when player joined the server", ex);
 		}
 	}
 	@EventHandler(priority = EventPriority.HIGHEST)
@@ -191,7 +191,7 @@ public class Main extends JavaPlugin implements Listener, MainClass{
 			}
 			Shared.data.remove(e.getPlayer().getUniqueId());
 		} catch (Throwable t) {
-			Shared.error(null, "An error occured when player left server", t);
+			Shared.error(null, "An error occurred when player left server", t);
 			Shared.data.remove(e.getPlayer().getUniqueId());
 		}
 	}
@@ -206,7 +206,7 @@ public class Main extends JavaPlugin implements Listener, MainClass{
 			String to = p.world = e.getPlayer().getWorld().getName();
 			p.onWorldChange(from, to);
 		} catch (Throwable ex) {
-			Shared.error(null, "An error occured when processing PlayerChangedWorldEvent", ex);
+			Shared.error(null, "An error occurred when processing PlayerChangedWorldEvent", ex);
 		}
 	}
 	@EventHandler

--- a/src/me/neznamy/tab/platforms/bukkit/unlimitedtags/NameTagX.java
+++ b/src/me/neznamy/tab/platforms/bukkit/unlimitedtags/NameTagX.java
@@ -96,6 +96,10 @@ public class NameTagX implements Listener{
 	public void a(PlayerMoveEvent e) {
 		if (Shared.disabled || !enable) return;
 		ITabPlayer p = Shared.getPlayer(e.getPlayer().getUniqueId());
+		if (p == null) {
+			Shared.error(null, "Data of " + e.getPlayer().getName() + " did not exist when player moved");
+			return;
+		}
 		if (p.previewingNametag) Shared.runTask("processing move", Feature.NAMETAGX, new Runnable() {
 
 			public void run() {

--- a/src/me/neznamy/tab/platforms/bungee/Main.java
+++ b/src/me/neznamy/tab/platforms/bungee/Main.java
@@ -131,7 +131,7 @@ public class Main extends Plugin implements Listener, MainClass{
 			}
 
 		} catch (Throwable ex){
-			Shared.error(null, "An error occured when player joined/changed server", ex);
+			Shared.error(null, "An error occurred when player joined/changed server", ex);
 		}
 	}
 	@EventHandler
@@ -179,7 +179,7 @@ public class Main extends Plugin implements Listener, MainClass{
 						if (team != null && killPacket(team)) return;
 					}
 				} catch (Throwable e){
-					Shared.error(null, "An error occured when analyzing packets", e);
+					Shared.error(null, "An error occurred when analyzing packets", e);
 				}
 				super.write(context, packet, channelPromise);
 			}

--- a/src/me/neznamy/tab/platforms/velocity/Main.java
+++ b/src/me/neznamy/tab/platforms/velocity/Main.java
@@ -153,7 +153,7 @@ public class Main implements MainClass{
 				p.onWorldChange(from, to);
 			}
 		} catch (Throwable ex){
-			Shared.error(null, "An error occured when player joined/changed server", ex);
+			Shared.error(null, "An error occurred when player joined/changed server", ex);
 		}
 	}
 	/*	@Subscribe
@@ -191,7 +191,7 @@ public class Main implements MainClass{
 						if (killPacket((Team)packet)) return;
 					}
 				} catch (Throwable e){
-					Shared.error(null, "An error occured when analyzing packets", e);
+					Shared.error(null, "An error occurred when analyzing packets", e);
 				}
 				super.write(context, packet, channelPromise);
 			}

--- a/src/me/neznamy/tab/shared/ITabPlayer.java
+++ b/src/me/neznamy/tab/shared/ITabPlayer.java
@@ -20,7 +20,7 @@ import me.neznamy.tab.shared.packets.PacketPlayOutPlayerInfo;
 import me.neznamy.tab.shared.packets.PacketPlayOutPlayerListHeaderFooter;
 import me.neznamy.tab.shared.packets.UniversalPacketPlayOut;
 
-public abstract class ITabPlayer{
+public abstract class ITabPlayer {
 
 	public String name;
 	public UUID uniqueId;
@@ -67,65 +67,97 @@ public abstract class ITabPlayer{
 	}
 
 	//bukkit only
-	public String getNickname() {return getName();}
-	public String getMoney() {return "-";}
-	public void setTeamVisible(boolean p0) {}
-	public void restartArmorStands() {}
-	public boolean hasInvisibility() {return false;}
+	public String getNickname() {
+		return getName();
+	}
+
+	public String getMoney() {
+		return "-";
+	}
+
+	public void setTeamVisible(boolean p0) {
+	}
+
+	public void restartArmorStands() {
+	}
+
+	public boolean hasInvisibility() {
+		return false;
+	}
 
 	//per-type
 	public abstract String getGroupFromPermPlugin();
+
 	public abstract String[] getGroupsFromPermPlugin();
+
 	public abstract boolean hasPermission(String permission);
+
 	public abstract long getPing();
+
 	public abstract void sendPacket(Object nmsPacket);
+
 	public abstract void sendMessage(String message);
 
 	public boolean getTeamPush() {
 		return Configs.collision;
 	}
+
 	public String getName() {
 		return name;
 	}
+
 	public UUID getUniqueId() {
 		return uniqueId;
 	}
-	public UUID getTablistId(){
+
+	public UUID getTablistId() {
 		return tablistId;
 	}
+
 	public ProtocolVersion getVersion() {
 		return version;
 	}
+
 	public Object getChannel() {
 		return channel;
 	}
+
 	public String getTeamName() {
 		return teamName;
 	}
+
 	public String getRank() {
 		return rank;
 	}
+
 	public boolean isStaff() {
 		return hasPermission("tab.staff");
 	}
+
 	public void setActiveScoreboard(Scoreboard board) {
 		activeScoreboard = board;
 	}
+
 	public Scoreboard getActiveScoreboard() {
 		return activeScoreboard;
 	}
-	public List<BossBarLine> getActiveBossBars(){
+
+	public List<BossBarLine> getActiveBossBars() {
 		return activeBossBars;
 	}
+
 	public String getWorldName() {
 		return world;
 	}
+
 	public List<ArmorStand> getArmorStands() {
 		return armorStands;
 	}
+
 	public PlayerInfoData getInfoData() {
 		return infoData;
 	}
+
 	public String setProperty(String identifier, String rawValue) {
 		Property p = properties.get(identifier);
 		if (p == null) {
@@ -135,6 +167,7 @@ public abstract class ITabPlayer{
 		}
 		return rawValue;
 	}
+
 	public boolean isListNameUpdateNeeded() {
 		if (!Playerlist.enable) return false;
 		getGroup();
@@ -143,6 +176,7 @@ public abstract class ITabPlayer{
 		boolean tabsuffix = properties.get("tabsuffix").isUpdateNeeded();
 		return (tabprefix || customtabname || tabsuffix);
 	}
+
 	public void updatePlayerListName() {
 		isListNameUpdateNeeded(); //triggering updates to replaced values
 		try {
@@ -154,6 +188,7 @@ public abstract class ITabPlayer{
 			Shared.error(null, "Failed to create PacketPlayOutPlayerInfo", e);
 		}
 	}
+
 	public String getTabFormat(ITabPlayer other) {
 		Property prefix = properties.get("tabprefix");
 		Property name = properties.get("customtabname");
@@ -161,6 +196,7 @@ public abstract class ITabPlayer{
 		String format = prefix.get() + name.get() + suffix.get();
 		return (prefix.hasRelationalPlaceholders() || name.hasRelationalPlaceholders() || suffix.hasRelationalPlaceholders()) ? PluginHooks.PlaceholderAPI_setRelationalPlaceholders(this, other, format) : format;
 	}
+
 	public void updateTeam() {
 		if (disabledNametag) return;
 		String newName = buildTeamName();
@@ -175,10 +211,12 @@ public abstract class ITabPlayer{
 			NameTagLineManager.refreshNames(this);
 		}
 	}
+
 	private boolean getTeamVisibility() {
 		if (TABAPI.hasHiddenNametag(getUniqueId()) || Configs.SECRET_invisible_nametags) return false;
 		return !Configs.unlimitedTags && nameTagVisible;
 	}
+
 	public String getGroup() {
 		if (System.currentTimeMillis() - lastRefreshGroup > 1000L) {
 			lastRefreshGroup = System.currentTimeMillis();
@@ -186,6 +224,7 @@ public abstract class ITabPlayer{
 		}
 		return permissionGroup;
 	}
+
 	public void updateGroupIfNeeded(boolean updateDataIfChanged) {
 		String newGroup = null;
 		if (Configs.usePrimaryGroup) {
@@ -196,7 +235,7 @@ public abstract class ITabPlayer{
 				loop:
 					for (Object entry : Configs.primaryGroupFindingList) {
 						for (String playerGroup : playerGroups) {
-							if (playerGroup.equalsIgnoreCase(entry+"")) {
+							if (playerGroup.equalsIgnoreCase(entry + "")) {
 								newGroup = playerGroup;
 								break loop;
 							}
@@ -213,6 +252,7 @@ public abstract class ITabPlayer{
 			}
 		}
 	}
+
 	public void updateAll() {
 		setProperty("tablist-objective", TabObjective.rawValue);
 		setProperty("belowname-number", BelowName.number);
@@ -241,59 +281,72 @@ public abstract class ITabPlayer{
 		if (rank == null) rank = permissionGroup;
 		updateRawHeaderAndFooter();
 	}
+
 	private String getValue(Object property) {
 		String worldGroup = getWorldGroupOf(getWorldName());
 		String value;
-		if ((value = Configs.config.getString("per-" + Shared.separatorType + "-settings." + worldGroup + ".Users." + getName() + "." + property)) != null) return value;
+		if ((value = Configs.config.getString("per-" + Shared.separatorType + "-settings." + worldGroup + ".Users." + getName() + "." + property)) != null)
+			return value;
 		if ((value = Configs.config.getString("Users." + getName() + "." + property)) != null) return value;
-		if ((value = Configs.config.getString("per-" + Shared.separatorType + "-settings." + worldGroup + ".Groups." + permissionGroup + "." + property)) != null) return value;
-		if ((value = Configs.config.getString("per-" + Shared.separatorType + "-settings." + worldGroup + ".Groups._OTHER_." + property)) != null) return value;
+		if ((value = Configs.config.getString("per-" + Shared.separatorType + "-settings." + worldGroup + ".Groups." + permissionGroup + "." + property)) != null)
+			return value;
+		if ((value = Configs.config.getString("per-" + Shared.separatorType + "-settings." + worldGroup + ".Groups._OTHER_." + property)) != null)
+			return value;
 		if ((value = Configs.config.getString("Groups." + permissionGroup + "." + property)) != null) return value;
 		if ((value = Configs.config.getString("Groups._OTHER_." + property)) != null) return value;
 		return "";
 	}
+
 	private void updateRawHeaderAndFooter() {
 		String worldGroup = getWorldGroupOf(getWorldName());
-		String rawHeader = "";
-		String rawFooter = "";
+		StringBuilder rawHeader = new StringBuilder();
+		StringBuilder rawFooter = new StringBuilder();
 		List<Object> h = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".Users." + getName() + ".header");
 		if (h == null) h = Configs.config.getList("Users." + getName() + ".header");
-		if (h == null) h = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".Groups." + permissionGroup + ".header");
-		if (h == null) h = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".header");
+		if (h == null)
+			h = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".Groups." + permissionGroup + ".header");
+		if (h == null)
+			h = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".header");
 		if (h == null) h = Configs.config.getList("Groups." + permissionGroup + ".header");
 		if (h == null) h = Configs.config.getList("header");
 		if (h == null) h = new ArrayList<Object>();
 		List<Object> f = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".Users." + getName() + ".footer");
 		if (f == null) f = Configs.config.getList("Users." + getName() + ".footer");
-		if (f == null) f = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".Groups." + permissionGroup + ".footer");
-		if (f == null) f = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".footer");
+		if (f == null)
+			f = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".Groups." + permissionGroup + ".footer");
+		if (f == null)
+			f = Configs.config.getList("per-" + Shared.separatorType + "-settings." + worldGroup + ".footer");
 		if (f == null) f = Configs.config.getList("Groups." + permissionGroup + ".footer");
 		if (f == null) f = Configs.config.getList("footer");
 		if (f == null) f = new ArrayList<Object>();
 		int i = 0;
 		for (Object headerLine : h) {
-			if (++i > 1) rawHeader += "\n" + Shared.COLOR + "r";
-			rawHeader += headerLine;
+			if (++i > 1) rawHeader.append("\n" + Shared.COLOR + "r");
+			rawHeader.append(headerLine);
 		}
 		i = 0;
 		for (Object footerLine : f) {
-			if (++i > 1) rawFooter += "\n" + Shared.COLOR + "r";
-			rawFooter += footerLine;
+			if (++i > 1) rawFooter.append("\n" + Shared.COLOR + "r");
+			rawFooter.append(footerLine);
 		}
-		setProperty("header", rawHeader);
-		setProperty("footer", rawFooter);
+		setProperty("header", rawHeader.toString());
+		setProperty("footer", rawFooter.toString());
 	}
+
 	@SuppressWarnings("unchecked")
 	private String getWorldGroupOf(String world) {
-		Map<String, Object> worlds = (Map<String, Object>) Configs.config.get("per-" + Shared.separatorType + "-settings");
-		if (worlds == null || worlds.isEmpty()) return world;
+		Object rawWorlds = Configs.config.get("per-" + Shared.separatorType + "-settings");
+		if (!(rawWorlds instanceof Map)) return world;
+		Map<String, Object> worlds = (Map<String, Object>) rawWorlds;
+		if (worlds.isEmpty()) return world;
 		for (String worldGroup : worlds.keySet()) {
-			for(String localworld : worldGroup.split("-")) {
-				if (localworld.equalsIgnoreCase(world)) return worldGroup;
+			for (String localWorld : worldGroup.split("-")) {
+				if (localWorld.equalsIgnoreCase(world)) return worldGroup;
 			}
 		}
 		return world;
 	}
+
 	public String buildTeamName() {
 		if (Premium.is()) {
 			return Premium.sortingType.getTeamName(this);
@@ -337,7 +390,7 @@ public abstract class ITabPlayer{
 			name = name.substring(0, 15);
 		}
 		for (int i = 1; i <= 255; ++i) {
-			String name2 = name + (char)i;
+			String name2 = name + (char) i;
 			boolean nameUsed = false;
 			for (ITabPlayer d : Shared.getPlayers()) {
 				if (d.getTeamName() != null && d.getTeamName().equals(name2) && !d.getName().equals(getName())) {
@@ -350,6 +403,7 @@ public abstract class ITabPlayer{
 		}
 		return getName();
 	}
+
 	public void updateTeamData() {
 		if (disabledNametag) return;
 		Property tagprefix = properties.get("tagprefix");
@@ -370,6 +424,7 @@ public abstract class ITabPlayer{
 			}
 		}
 	}
+
 	public void registerTeam() {
 		if (disabledNametag) return;
 		Property tagprefix = properties.get("tagprefix");
@@ -382,22 +437,28 @@ public abstract class ITabPlayer{
 			PacketAPI.registerScoreboardTeam(all, teamName, currentPrefix, currentSuffix, lastVisibility = getTeamVisibility(), lastCollision = getTeamPush(), Arrays.asList(getName()));
 		}
 	}
+
 	public void registerTeam(ITabPlayer to) {
 		if (disabledNametag) return;
 		Property tagprefix = properties.get("tagprefix");
 		Property tagsuffix = properties.get("tagsuffix");
 		String replacedPrefix = tagprefix.get();
 		String replacedSuffix = tagsuffix.get();
-		if (tagprefix.hasRelationalPlaceholders()) replacedPrefix = PluginHooks.PlaceholderAPI_setRelationalPlaceholders(this, to, replacedPrefix);
-		if (tagsuffix.hasRelationalPlaceholders()) replacedSuffix = PluginHooks.PlaceholderAPI_setRelationalPlaceholders(this, to, replacedSuffix);
+		if (tagprefix.hasRelationalPlaceholders())
+			replacedPrefix = PluginHooks.PlaceholderAPI_setRelationalPlaceholders(this, to, replacedPrefix);
+		if (tagsuffix.hasRelationalPlaceholders())
+			replacedSuffix = PluginHooks.PlaceholderAPI_setRelationalPlaceholders(this, to, replacedSuffix);
 		PacketAPI.registerScoreboardTeam(to, teamName, replacedPrefix, replacedSuffix, getTeamVisibility(), getTeamPush(), Arrays.asList(getName()));
 	}
+
 	private void unregisterTeam(ITabPlayer to) {
 		PacketAPI.unregisterScoreboardTeam(to, teamName);
 	}
+
 	public void unregisterTeam() {
 		for (ITabPlayer p : Shared.getPlayers()) unregisterTeam(p);
 	}
+
 	public void onWorldChange(String from, String to) {
 		disabledHeaderFooter = Configs.disabledHeaderFooter.contains(to);
 		disabledTablistNames = Configs.disabledTablistNames.contains(to);
@@ -421,7 +482,7 @@ public abstract class ITabPlayer{
 		}
 		if (HeaderFooter.enable) {
 			if (disabledHeaderFooter) {
-				sendCustomPacket(new PacketPlayOutPlayerListHeaderFooter("",""));
+				sendCustomPacket(new PacketPlayOutPlayerListHeaderFooter("", ""));
 			} else {
 				HeaderFooter.refreshHeaderFooter(this, true);
 			}
@@ -429,7 +490,7 @@ public abstract class ITabPlayer{
 		if (NameTag16.enable || Configs.unlimitedTags) {
 			if (disabledNametag) {
 				unregisterTeam();
-			} else if (Configs.disabledNametag.contains(from)){
+			} else if (Configs.disabledNametag.contains(from)) {
 				registerTeam();
 			} else {
 				updateTeam();
@@ -444,7 +505,7 @@ public abstract class ITabPlayer{
 				TabObjective.playerJoin(this);
 			}
 		}
-		if (BelowName.enable){
+		if (BelowName.enable) {
 			if (disabledBelowname && !Configs.disabledBelowname.contains(from)) {
 				BelowName.unload(this);
 			}
@@ -457,6 +518,7 @@ public abstract class ITabPlayer{
 			ScoreboardManager.register(this);
 		}
 	}
+
 	public void detectBossBarsAndSend() {
 		activeBossBars.clear();
 		if (disabledBossbar || !bossbarVisible) return;
@@ -482,20 +544,23 @@ public abstract class ITabPlayer{
 				}
 			}
 	}
+
 	public void sendCustomPacket(UniversalPacketPlayOut packet) {
 		try {
 			sendPacket(Shared.mainClass.buildPacket(packet, version));
 		} catch (Exception e) {
-			Shared.error(null, "An error occured when creating " + packet.getClass().getSimpleName(), e);
+			Shared.error(null, "An error occurred when creating " + packet.getClass().getSimpleName(), e);
 		}
 	}
+
 	public void sendCustomPacket(PacketPlayOut packet) {
 		try {
 			sendPacket(packet.toNMS(version));
 		} catch (Exception e) {
-			Shared.error(null, "An error occured when creating " + packet.getClass().getSimpleName(), e);
+			Shared.error(null, "An error occurred when creating " + packet.getClass().getSimpleName(), e);
 		}
 	}
+
 	public void forceUpdateDisplay() {
 		if (Playerlist.enable && !disabledTablistNames) updatePlayerListName();
 		if ((NameTag16.enable || Configs.unlimitedTags) && !disabledNametag) {

--- a/src/me/neznamy/tab/shared/PluginHooks.java
+++ b/src/me/neznamy/tab/shared/PluginHooks.java
@@ -208,7 +208,7 @@ public class PluginHooks {
 		try {
 			return ((Permission)Vault_permission).getPlayerGroups(((TabPlayer)p).player);
 		} catch (Throwable e) {
-			return Shared.error(new String[] {"null"}, "An error occured when getting permission groups of " + p.getName() + " using Vault", e);
+			return Shared.error(new String[] {"null"}, "An error occurred when getting permission groups of " + p.getName() + " using Vault", e);
 		}
 	}
 	public static double Vault_getMoney(ITabPlayer p) {
@@ -218,7 +218,7 @@ public class PluginHooks {
 		try {
 			return ((Permission)Vault_permission).getPrimaryGroup(((TabPlayer)p).player);
 		} catch (Throwable e) {
-			return Shared.error("null", "An error occured when getting permission group of " + p.getName() + " using Vault", e);
+			return Shared.error("null", "An error occurred when getting permission group of " + p.getName() + " using Vault", e);
 		}
 	}
 	public static void Vault_loadProviders() {
@@ -233,7 +233,7 @@ public class PluginHooks {
 		try {
 			return Via.getAPI().getPlayerVersion(p.getUniqueId());
 		} catch (Throwable e) {
-			return Shared.error(ProtocolVersion.SERVER_VERSION.getNetworkId(), "An error occured when getting protocol version of " + p.getName() + " using ViaVersion", e);
+			return Shared.error(ProtocolVersion.SERVER_VERSION.getNetworkId(), "An error occurred when getting protocol version of " + p.getName() + " using ViaVersion", e);
 		}
 	}
 	public static boolean xAntiAFK_isAfk(ITabPlayer p) {

--- a/src/me/neznamy/tab/shared/Shared.java
+++ b/src/me/neznamy/tab/shared/Shared.java
@@ -99,7 +99,7 @@ public class Shared {
 				buf.close();
 			}
 		} catch (Throwable ex) {
-			print('c', "An error occured when generating error message");
+			print('c', "An error occurred when generating error message");
 			ex.printStackTrace();
 			print('c', "Original error: " + message);
 			if (t != null) t.printStackTrace();
@@ -163,7 +163,7 @@ public class Shared {
 					} catch (InterruptedException pluginDisabled) {
 						break;
 					} catch (Throwable t) {
-						error(null, "An error occured when " + description, t);
+						error(null, "An error occurred when " + description, t);
 					}
 				}
 			}
@@ -178,7 +178,7 @@ public class Shared {
 					r.run();
 					featureCPU(feature, System.nanoTime()-time);
 				} catch (Throwable t) {
-					error(null, "An error occured when " + description, t);
+					error(null, "An error occurred when " + description, t);
 				}
 			}
 		});

--- a/src/me/neznamy/tab/shared/placeholders/Placeholder.java
+++ b/src/me/neznamy/tab/shared/placeholders/Placeholder.java
@@ -24,7 +24,7 @@ public abstract class Placeholder {
 		try {
 			return s.replace(identifier, getValue(p));
 		} catch (Throwable t) {
-			return Shared.error(s, "An error occured when setting placeholder \"" + identifier + "\"" + (p == null ? "" : " for " + p.getName()), t);
+			return Shared.error(s, "An error occurred when setting placeholder \"" + identifier + "\"" + (p == null ? "" : " for " + p.getName()), t);
 		}
 	}
 	public abstract String getValue(ITabPlayer p);

--- a/src/org/json/simple/parser/Yylex.java
+++ b/src/org/json/simple/parser/Yylex.java
@@ -450,7 +450,7 @@ int getPosition(){
 
 
   /**
-   * Reports an error that occured while scanning.
+   * Reports an error that occurred while scanning.
    *
    * In a wellformed scanner (no or only correct usage of 
    * yypushback(int) and a match-all fallback rule) this method 


### PR DESCRIPTION
Basically the entire plugin will not enable correctly for anyone with config generated before the improved `per-world-settings` config changes recently added (2.5.5-pre9).

This is because of an incorrect data type:
* Old (list): 
```
per-world-settings: []
```
* New (map): 
```
per-world-settings:
  world1:
    header:
      - "an example of world with custom"
    footer:
      - "header/footer and prefix/suffix"
    Groups:
      Owner:
        tabprefix: "&0&l[&a&lOwner&0&l] &a"
        tagprefix: "&2&lOwner &a"
  world2-world3:
    header:
      - "This is a shared header for"
      - "world2 and world3"
```

I fixed this without any notification but ideally a warning message should be logged or config should be auto-updated.

I also ran an auto-format on the ITabPlayer file, fixed an incorrect spelling (occured -> occurred) and replaced a String loop with a StringBuilder to slightly improve performance.