### PR TITLE
Fixing nametag position issue

### DIFF
--- a/src/me/neznamy/tab/platforms/bukkit/features/unlimitedtags/NameTagX.java
+++ b/src/me/neznamy/tab/platforms/bukkit/features/unlimitedtags/NameTagX.java
@@ -195,6 +195,24 @@ public class NameTagX implements Listener, SimpleFeature, RawPacketFeature, Cust
 		});
 	}
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void a(PlayerRespawnEvent e) {
+		ITabPlayer p = Shared.getPlayer(e.getPlayer().getUniqueId());
+		if (p == null) return;
+		if (!p.disabledNametag) Shared.cpu.runMeasuredTask("processing PlayerRespawnEvent", "NameTagX - PlayerRespawnEvent", new Runnable() {
+			public void run() {
+				for (ArmorStand as : p.getArmorStands()) {
+					as.updateLocation(e.getRespawnLocation());
+					List<ITabPlayer> nearbyPlayers = as.getNearbyPlayers();
+					synchronized (nearbyPlayers){
+						for (ITabPlayer nearby : nearbyPlayers) {
+							nearby.sendPacket(as.getNMSTeleportPacket(nearby));
+						}
+					}
+				}
+			}
+		});
+	}
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void a(PlayerTeleportEvent e) {
 		ITabPlayer p = Shared.getPlayer(e.getPlayer().getUniqueId());
 		if (p == null) return;


### PR DESCRIPTION
Whenever a player respawns, the nametag will not update its position until said player starts moving, usually showing at the place of death until so. I simply copied the content of the PlayerTeleportEvent handler to paste into a new PlayerRespawnEvent one, while adjusting the measured task title accordingly.
Tested this on a 1.15.2 paper-spigot server, worked fine.