### PR TITLE
Fixed ViaVersion dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
 		<dependency>
 			<groupId>us.myles</groupId>
 			<artifactId>viaversion</artifactId>
-			<version>3.2.0</version>
+			<version>3.2.1-SNAPSHOT</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
@@ -367,7 +367,7 @@
 			<artifactId>Velocity</artifactId>
 			<version>1.1.0</version>
 			<scope>system</scope>
-			<systemPath>${project.basedir}${file.separator}jars${file.separator}velocity-1.1.0.jar</systemPath>
+			<systemPath>/home/asineth/Code/TAB/jars/velocity-1.1.0.jar</systemPath>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
Changed 3.2.0 to 3.2.1-SNAPSHOT, since 3.2.0 will result in a 404 while building. It builds fine now.