### PR TITLE
Added ViaVersion maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,10 @@
 			<id>luck-repo</id>
 			<url>https://ci.lucko.me/plugin/repository/everything/</url>
 		</repository>
+		<repository>
+			<id>viaversion</id>
+			<url>https://repo.viaversion.com/</url>
+		</repository>
 
 	</repositories>
 


### PR DESCRIPTION
Without this commit, Maven will attempt to pull down ViaVersion from Spigot instead of the ViaVersion repo.
```
[INFO] ---------------------------< me.neznamy:TAB >---------------------------
[INFO] Building TAB 2.8.8
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The POM for us.myles:viaversion:jar:3.2.0 is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.317 s
[INFO] Finished at: 2020-11-04T09:12:46-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project TAB: Could not resolve dependencies for project me.neznamy:TAB:jar:2.8.8: Failure to find us.myles:viaversion:jar:3.2.0 in https://hub.spigotmc.org/nexus/content/repositories/snapshots/ was cached in the local repository, resolution will not be reattempted until the update interval of spigot-repo has elapsed or updates are forced -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```