### PR TITLE
Fix using wrong cpu usage deserialization packet type

### DIFF
--- a/src/main/java/me/neznamy/tab/shared/FeatureManager.java
+++ b/src/main/java/me/neznamy/tab/shared/FeatureManager.java
@@ -330,7 +330,7 @@ public class FeatureManager {
 	public boolean onHeaderFooter(TabPlayer packetReceiver, Object packet) throws Exception {
 		long time = System.nanoTime();
 		PacketPlayOutPlayerListHeaderFooter display = tab.getPacketBuilder().readHeaderFooter(packet, packetReceiver.getVersion());
-		tab.getCPUManager().addTime(TabFeature.PACKET_DESERIALIZING, UsageType.PACKET_DISPLAY_OBJECTIVE, System.nanoTime()-time);
+		tab.getCPUManager().addTime(TabFeature.PACKET_DESERIALIZING, UsageType.PACKET_HEADER_FOOTER, System.nanoTime()-time);
 		for (Feature f : getAllFeatures()) {
 			if (!(f instanceof HeaderFooterPacketListener)) continue;
 			time = System.nanoTime();


### PR DESCRIPTION
I think there's a typo in the onHeaderFooter method in FeatureManager.java. This leads to that the cpu usage for deserialization will be calculated for the wrong type of packet.

https://github.com/NEZNAMY/TAB/blob/9f3995198b2d6bd84d188f5a93bb78fb785e6ee7/src/main/java/me/neznamy/tab/shared/FeatureManager.java#L330-L333

I changed it to the packet header and footer usage type, so that the cpu usage will be correct.