### PR TITLE
Remove unnecessary color code

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/Groups.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/Groups.java
@@ -27,7 +27,7 @@ public class Groups extends SortingType {
 		if (chars == null) {
 			chars = String.valueOf(sortedGroups.size()+1);
 			if (!group.equals("<null>")) {
-				TAB.getInstance().getErrorManager().oneTimeConsoleError(String.format("Group \"%s\" is not defined in sorting list! This will result in players in that group not being sorted correctly. To fix this, add group \"%s\" into &egroup-sorting-priority-list in config.yml. Your current list: %s", group, group, sortedGroups.keySet()));
+				TAB.getInstance().getErrorManager().oneTimeConsoleError(String.format("Group \"%s\" is not defined in sorting list! This will result in players in that group not being sorted correctly. To fix this, add group \"%s\" into group-sorting-priority-list in config.yml. Your current list: %s", group, group, sortedGroups.keySet()));
 			}
 			p.setTeamNameNote(p.getTeamNameNote() + "&cPlayer's primary group is not in sorting list. &r");
 		} else {


### PR DESCRIPTION
Remove unnecessary (and incorrectly shown) color code from "Group is not defined in sorting list!" error message