### PR TITLE
Set velocity version to 3.0.0

### DIFF
--- a/velocity/pom.xml
+++ b/velocity/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>com.velocitypowered</groupId>
 			<artifactId>velocity-api</artifactId>
-			<version>1.1.0</version>
+			<version>3.0.0</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
I was looking to update the velocity version to 3.0.0 for a client, but switching the version from the maven file all seems to work fine.