### PR TITLE
Velocity refresh players on join Fix.

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
@@ -183,12 +183,20 @@ public class FeatureManager {
 	 * @param disconnectedPlayer - player who disconnected
 	 */
 	public void onQuit(TabPlayer disconnectedPlayer) {
-		if (disconnectedPlayer == null) return;
-		for (Feature f : getAllFeatures()) {
-			if (!(f instanceof QuitEventListener)) continue;
+		if (disconnectedPlayer == null) {
+			return;
+		}
+
+		for (Feature feature : getAllFeatures()) {
+			if (!(feature instanceof QuitEventListener)) {
+				continue;
+			}
+
 			long time = System.nanoTime();
-			((QuitEventListener)f).onQuit(disconnectedPlayer);
-			tab.getCPUManager().addTime(f.getFeatureType(), UsageType.PLAYER_QUIT_EVENT, System.nanoTime()-time);
+			QuitEventListener quitListener = (QuitEventListener) feature;
+
+			quitListener.onQuit(disconnectedPlayer);
+			tab.getCPUManager().addTime(feature.getFeatureType(), UsageType.PLAYER_QUIT_EVENT, System.nanoTime()-time);
 		}
 		tab.removePlayer(disconnectedPlayer);
 	}
@@ -205,11 +213,16 @@ public class FeatureManager {
 		}
 		long millis = System.currentTimeMillis();
 		tab.addPlayer(connectedPlayer);
-		for (Feature f : getAllFeatures()) {
-			if (!(f instanceof JoinEventListener)) continue;
+		for (Feature feature : getAllFeatures()) {
+			if (!(feature instanceof JoinEventListener)) {
+				continue;
+			}
+
 			long time = System.nanoTime();
-			((JoinEventListener)f).onJoin(connectedPlayer);
-			tab.getCPUManager().addTime(f.getFeatureType(), UsageType.PLAYER_JOIN_EVENT, System.nanoTime()-time);
+			JoinEventListener joinEvent = (JoinEventListener) feature;
+
+			joinEvent.onJoin(connectedPlayer);
+			tab.getCPUManager().addTime(feature.getFeatureType(), UsageType.PLAYER_JOIN_EVENT, System.nanoTime()-time);
 		}
 		((ITabPlayer)connectedPlayer).markAsLoaded();
 		tab.debug("Player join of " + connectedPlayer.getName() + " processed in " + (System.currentTimeMillis()-millis) + "ms");
@@ -228,8 +241,10 @@ public class FeatureManager {
 			tab.getCPUManager().runTaskLater(100, "processing delayed world/server switch", TabFeature.OTHER, UsageType.WORLD_SWITCH_EVENT, () -> onWorldChange(playerUUID, to));
 			return;
 		}
+
 		String from = changed.getWorldName();
-		((ITabPlayer)changed).setWorldName(to);
+		((ITabPlayer) changed).setWorldName(to);
+
 		for (Feature f : getAllFeatures()) {
 			if (!(f instanceof WorldChangeListener)) continue;
 			long time = System.nanoTime();


### PR DESCRIPTION
This PR fixes many problems of velocity support but does not solve all of them.
#### Fix:
- Joining to another server.
- Joining other players to server.
- change worlds.
#### Bugs:
- if you connect to another server, you cannot see players from the previous server on the tablist.
e.g. you `lobby -> survival`
you see only players from survival (but if more people enter the lobby, you will see them already)

I'm going to fix the velocity support bugs 100%
before merging PR, test if bungee-cord versions work, etc.