### PR TITLE
Load TAB after PremiumVanish

### DIFF
--- a/bungeecord/src/main/resources/bungee.yml
+++ b/bungeecord/src/main/resources/bungee.yml
@@ -4,4 +4,4 @@ version: @version@
 author: NEZNAMY
 description: @description@
 depends: []
-softDepends: [RedisBungee, LuckPerms]
+softDepends: [RedisBungee, LuckPerms, PremiumVanish]


### PR DESCRIPTION
When BungeeTabPlayer#isVanished uses PV's API, PV needs to actually be enabled, not just loaded. A soft-dependency should ensure that PV is fully enabled before TAB's onEnable() uses the API. It doesn't look like Bungee's PluginManager has a Plugin#isEnabled method.
This should fix [this error](https://pastebin.com/5B0ia4Vc ) that someone reported to me.