### PR TITLE
Fixed localization issue when dealing with floats numbers

### DIFF
--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/BukkitPlaceholderRegistry.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/BukkitPlaceholderRegistry.java
@@ -95,7 +95,7 @@ public class BukkitPlaceholderRegistry implements PlaceholderRegistry {
 	@SuppressWarnings("deprecation")
 	@Override
 	public void registerPlaceholders(PlaceholderManager manager) {
-		NumberFormat roundDown = NumberFormat.getInstance();
+		NumberFormat roundDown = NumberFormat.getNumberInstance(Locale.ENGLISH);
 		roundDown.setRoundingMode(RoundingMode.DOWN);
 		roundDown.setMaximumFractionDigits(2);
 		manager.registerPlayerPlaceholder("%displayname%", 500, p -> ((Player) p.getPlayer()).getDisplayName());


### PR DESCRIPTION
I was trying to color code the '%mspt%' placeholder on a server with a German locale. The issue was that the decimal separator in Germany is a comma ',' which the number comparing logic ignored. So my fix was to just change the locale to English so it would work in any case.

The error looked like this:
32,496 became 32496.0