### PR TITLE
fix nametag preview help text

### DIFF
--- a/shared/src/main/resources/messages.yml
+++ b/shared/src/main/resources/messages.yml
@@ -40,7 +40,7 @@ help-menu:
   - "      - &7Reloads plugin and config"
   - " &8>> &3&l/tab &9group&3/&9player &3<name> &9<property> &3<value...>"
   - "      - &7Do &8/tab group/player &7to show properties"
-  - " &8>> &3&l/tab ntpreview"
+  - " &8>> &3&l/tab nametag preview"
   - "      - &7Shows your nametag for yourself, for testing purposes"
   - " &8>> &3&l/tab announce bar &3<name> &9<seconds>"
   - "      - &7Temporarily displays bossbar to all players"


### PR DESCRIPTION
it seems new update `/tab ntpreview` has been replaced with `/tab nametag preview`
Help text was not updated