### PR TITLE
Add option to hide scoreboard line when its empty

### DIFF
--- a/bukkit/src/main/resources/bukkitconfig.yml
+++ b/bukkit/src/main/resources/bukkitconfig.yml
@@ -123,6 +123,7 @@ scoreboard:
   toggle-command: /sb
   remember-toggle-choice: false
   hidden-by-default: false
+  hide-when-empty: false
   use-numbers: false
   static-number: 0
   delay-on-join-milliseconds: 0

--- a/bungeecord/src/main/resources/proxyconfig.yml
+++ b/bungeecord/src/main/resources/proxyconfig.yml
@@ -138,6 +138,7 @@ scoreboard:
   toggle-command: /sb
   remember-toggle-choice: false
   hidden-by-default: false
+  hide-when-empty: false
   use-numbers: false
   static-number: 0
   delay-on-join-milliseconds: 0

--- a/krypton/src/main/resources/kryptonconfig.yml
+++ b/krypton/src/main/resources/kryptonconfig.yml
@@ -128,6 +128,7 @@ scoreboard:
   toggle-command: /sb
   remember-toggle-choice: false
   hidden-by-default: false
+  hide-when-empty: false
   # when enabled, will show 0-14 in red next to lines
   use-numbers: false
   # if use-numbers is disabled, this number will show in red next to all lines

--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardManagerImpl.java
@@ -27,6 +27,7 @@ public class ScoreboardManagerImpl extends TabFeature implements ScoreboardManag
     private final boolean useNumbers = TAB.getInstance().getConfiguration().getConfig().getBoolean("scoreboard.use-numbers", false);
     private final boolean rememberToggleChoice = TAB.getInstance().getConfiguration().getConfig().getBoolean("scoreboard.remember-toggle-choice", false);
     private final boolean hiddenByDefault = TAB.getInstance().getConfiguration().getConfig().getBoolean("scoreboard.hidden-by-default", false);
+    private final boolean hideWhenEmpty = TAB.getInstance().getConfiguration().getConfig().getBoolean("scoreboard.hide-when-empty", false);
     private final boolean respectOtherPlugins = TAB.getInstance().getConfiguration().getConfig().getBoolean("scoreboard.respect-other-plugins", true);
     private final int staticNumber = TAB.getInstance().getConfiguration().getConfig().getInt("scoreboard.static-number", 0);
     private final int joinDelay = TAB.getInstance().getConfiguration().getConfig().getInt("scoreboard.delay-on-join-milliseconds", 0);
@@ -190,6 +191,10 @@ public class ScoreboardManagerImpl extends TabFeature implements ScoreboardManag
 
     public int getStaticNumber() {
         return staticNumber;
+    }
+
+    public boolean isHideWhenEmpty() {
+        return hideWhenEmpty;
     }
 
     /**

--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/lines/ScoreboardLine.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/lines/ScoreboardLine.java
@@ -125,6 +125,9 @@ public abstract class ScoreboardLine extends TabFeature implements Line {
      *          suffix
      */
     protected void addLine(TabPlayer p, String fakePlayer, String prefix, String suffix) {
+        if (parent.getManager().isHideWhenEmpty() && teamName.isEmpty()) {
+            return;
+        }
         p.sendCustomPacket(new PacketPlayOutScoreboardScore(Action.CHANGE, ScoreboardManagerImpl.OBJECTIVE_NAME, fakePlayer, getNumber(p)), TabConstants.PacketCategory.SCOREBOARD_LINES);
         p.sendCustomPacket(new PacketPlayOutScoreboardTeam(teamName, prefix, suffix, "never", "never", Collections.singletonList(fakePlayer), 0), TabConstants.PacketCategory.SCOREBOARD_LINES);
     }


### PR DESCRIPTION
This just adds a boolean to allow users to hide a scoreboard line if its fully empty. This is useful when doing HCF styled scoreboards.