### PR TITLE
Remove unnecessary team registration

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
@@ -92,17 +92,21 @@ public class NameTag extends TabFeature implements TeamManager {
         ((ITabPlayer) connectedPlayer).setTeamName(getSorting().getTeamName(connectedPlayer));
         updateProperties(connectedPlayer);
         hiddenNameTagFor.put(connectedPlayer, new ArrayList<>());
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
-            if (all == connectedPlayer) continue; //avoiding double registration
-            if (!isDisabledPlayer(all)) {
-                registerTeam(all, connectedPlayer);
-            }
-        }
         if (isDisabled(connectedPlayer.getServer(), connectedPlayer.getWorld())) {
             addDisabledPlayer(connectedPlayer);
             return;
         }
-        registerTeam(connectedPlayer);
+
+        // no need to register a team if we are using armorstands
+        if (!TAB.getInstance().getFeatureManager().isFeatureEnabled("NameTagX")) {
+            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+                if (all == connectedPlayer) continue; //avoiding double registration
+                if (!isDisabledPlayer(all)) {
+                    registerTeam(all, connectedPlayer);
+                }
+            }
+            registerTeam(connectedPlayer);
+        }
     }
 
     @Override


### PR DESCRIPTION
TAB was overriding the teams regardless the setting "anti-override". It only should do that when unlimited mode is disabled.
<br>
Tested with unlimited mode both enabled and disabled, does not seem to cause any problem.