### PR TITLE
Returns support Velocity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ val platforms = setOf(
     projects.bukkit,
     projects.bungeecord,
 //    projects.krypton,
-//    projects.velocity
+    projects.velocity
 ).map { it.dependencyProject }
 
 val special = setOf(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ event = "3.0.0"
 bukkit = "1.16.5-R0.1-SNAPSHOT"
 bungeecord = "1.19-R0.1-SNAPSHOT"
 krypton = "0.59.2"
-velocity = "1.1.0"
+velocity = "3.0.1"
 
 # Platform extras
 placeholderapi = "2.11.1"

--- a/jar/build.gradle.kts
+++ b/jar/build.gradle.kts
@@ -8,7 +8,7 @@ val platforms = setOf(
     rootProject.projects.bukkit,
     rootProject.projects.bungeecord,
 //    rootProject.projects.krypton,
-//    rootProject.projects.velocity
+    rootProject.projects.velocity
 ).map { it.dependencyProject }
 
 tasks {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,7 +25,7 @@ rootProject.name = "TAB"
 include(":api")
 include(":shared")
 //include(":krypton")
-//include(":velocity")
+include(":velocity")
 include(":bukkit")
 include(":bungeecord")
 include(":jar")

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityEventListener.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityEventListener.java
@@ -7,7 +7,6 @@ import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
 import com.velocitypowered.api.event.player.ServerPostConnectEvent;
 import com.velocitypowered.api.proxy.Player;
-
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.proxy.ProxyPlatform;
@@ -29,7 +28,7 @@ public class VelocityEventListener {
         TAB.getInstance().getCPUManager().runTask(() ->
                 TAB.getInstance().getFeatureManager().onQuit(TAB.getInstance().getPlayer(e.getPlayer().getUniqueId())));
     }
-    
+
     /**
      * Listener to join / server switch to forward the event to all features
      *
@@ -39,14 +38,26 @@ public class VelocityEventListener {
     @Subscribe
     public void onConnect(ServerPostConnectEvent e){
         Player p = e.getPlayer();
+
         if (TAB.getInstance().isDisabled()) return;
-        TAB.getInstance().getCPUManager().runTaskLater(200, () -> {
-            if (TAB.getInstance().getPlayer(p.getUniqueId()) == null) {
-                TAB.getInstance().getCPUManager().runTask(() -> TAB.getInstance().getFeatureManager().onJoin(new VelocityTabPlayer(p)));
-            } else {
-                TAB.getInstance().getFeatureManager().onServerChange(p.getUniqueId(), p.getCurrentServer().isPresent() ? p.getCurrentServer().get().getServerInfo().getName() : "null");
-            }
-        });
+
+        TAB.getInstance().getCPUManager().runMeasuredTask(
+                "EventListener",
+                TabConstants.CpuUsageCategory.PLAYER_JOIN,
+                () -> {
+                    if (TAB.getInstance().getPlayer(p.getUniqueId()) == null) {
+                        TAB.getInstance().getCPUManager().runTask(
+                                () -> TAB.getInstance().getFeatureManager().onJoin(new VelocityTabPlayer(p))
+                        );
+                    } else {
+                        TAB.getInstance().getFeatureManager().onServerChange(
+                                p.getUniqueId(),
+                                p.getCurrentServer().isPresent() ?
+                                        p.getCurrentServer().get().getServerInfo().getName() : "null"
+                        );
+                    }
+                }
+        );
     }
 
     /**

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTabPlayer.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTabPlayer.java
@@ -108,8 +108,8 @@ public class VelocityTabPlayer extends ProxyTabPlayer {
      *          Packet request to handle
      */
     private void handle(PacketPlayOutPlayerListHeaderFooter packet) {
-        getPlayer().getTabList().setHeaderAndFooter(Main.getInstance().convertComponent(packet.getHeader(), getVersion()),
-                Main.getInstance().convertComponent(packet.getFooter(), getVersion()));
+        getPlayer().sendPlayerListHeader(Main.getInstance().convertComponent(packet.getHeader(), getVersion()));
+        getPlayer().sendPlayerListFooter(Main.getInstance().convertComponent(packet.getFooter(), getVersion()));
     }
 
     /**


### PR DESCRIPTION
I like your plugin, but I use Velocity in a proxy server role.
The plugin already has Velocity implementation, but it is disabled by default, so why?
I updated Velocity API and replaced deprecated methods.
It looks a little strange to use your own implementation of the profiling tool, for what?