### PR TITLE
Fix 1.19.1 compatibility

### DIFF
--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/BukkitModernNMSStorage.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/BukkitModernNMSStorage.java
@@ -48,7 +48,7 @@ public class BukkitModernNMSStorage extends ModernNMSStorage {
         PlayerConnection = Class.forName("net.minecraft.server.network.PlayerConnection");
         PacketPlayOutPlayerListHeaderFooter = Class.forName("net.minecraft.network.protocol.game.PacketPlayOutPlayerListHeaderFooter");
         PacketPlayOutChat = getModernClass("net.minecraft.network.protocol.game.ClientboundSystemChatPacket",
-                "net.minecraft.network.protocol.game.PacketPlayOutChat");
+                "net.minecraft.network.protocol.game.PacketPlayOutChat"); // Not found
         if (minorVersion < 19) {
             ChatMessageType = Class.forName("net.minecraft.network.chat.ChatMessageType");
         }

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/BukkitModernNMSStorage.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/BukkitModernNMSStorage.java
@@ -48,7 +48,7 @@ public class BukkitModernNMSStorage extends ModernNMSStorage {
         PlayerConnection = Class.forName("net.minecraft.server.network.PlayerConnection");
         PacketPlayOutPlayerListHeaderFooter = Class.forName("net.minecraft.network.protocol.game.PacketPlayOutPlayerListHeaderFooter");
         PacketPlayOutChat = getModernClass("net.minecraft.network.protocol.game.ClientboundSystemChatPacket",
-                "net.minecraft.network.protocol.game.PacketPlayOutChat"); // Not found
+                "net.minecraft.network.protocol.game.PacketPlayOutChat");
         if (minorVersion < 19) {
             ChatMessageType = Class.forName("net.minecraft.network.chat.ChatMessageType");
         }

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/MojangModernNMSStorage.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/MojangModernNMSStorage.java
@@ -34,7 +34,7 @@ public class MojangModernNMSStorage extends ModernNMSStorage {
 
     @Override
     public void loadClasses() throws ClassNotFoundException {
-        IChatBaseComponent = Class.forName("net.minecraft.network.chat.Component");
+        IChatBaseComponent = Class.forName("net.minecraft.network.chat.ComponentContents");
         ChatSerializer = Class.forName("net.minecraft.network.chat.Component$Serializer");
         World = Class.forName("net.minecraft.world.level.Level");
         EntityArmorStand = Class.forName("net.minecraft.world.entity.decoration.ArmorStand");

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/NMSStorage.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/NMSStorage.java
@@ -253,7 +253,7 @@ public abstract class NMSStorage {
             ChatMessageType_values = getEnumValues(ChatMessageType);
         }
         if (minorVersion >= 19) {
-            newPacketPlayOutChat = PacketPlayOutChat.getConstructor(IChatBaseComponent, int.class);
+            newPacketPlayOutChat = PacketPlayOutChat.getConstructor(IChatBaseComponent, boolean.class); // int = NoSuchMethod
         } else if (minorVersion >= 16) {
             newPacketPlayOutChat = PacketPlayOutChat.getConstructor(IChatBaseComponent, ChatMessageType, UUID.class);
         } else if (minorVersion >= 12) {

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/NMSStorage.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/nms/NMSStorage.java
@@ -253,7 +253,7 @@ public abstract class NMSStorage {
             ChatMessageType_values = getEnumValues(ChatMessageType);
         }
         if (minorVersion >= 19) {
-            newPacketPlayOutChat = PacketPlayOutChat.getConstructor(IChatBaseComponent, boolean.class); // int = NoSuchMethod
+            newPacketPlayOutChat = PacketPlayOutChat.getConstructor(IChatBaseComponent, boolean.class);
         } else if (minorVersion >= 16) {
             newPacketPlayOutChat = PacketPlayOutChat.getConstructor(IChatBaseComponent, ChatMessageType, UUID.class);
         } else if (minorVersion >= 12) {


### PR DESCRIPTION
Fix https://github.com/NEZNAMY/TAB/issues/663

Might break compatibility with 1.19 (but why not update to 1.19.1)

Haven't found a replacement class for Bukkit's `PacketPlayOutChat` yet, so will use `MojangModernNMSStorage`

Tested in my server.