### PR TITLE
bump org.yaml:snakeyaml to 1.33

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ metadata.format.version = "1.1"
 # API
 netty = "4.1.80.Final"
 jsonSimple = "1.1.1"
-snakeyaml = "1.30"
+snakeyaml = "1.33"
 yamlAssist = "1.0.5"
 gson = "2.9.1"
 slf4j = "1.7.36"


### PR DESCRIPTION
snakeyaml 1.30 is affected by 5 vulnerabilities and should be upgraded to the latest version