### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,22 +11,22 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.3.0 #https://github.com/actions/checkout/releases
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.9.0 #https://github.com/actions/setup-java/releases
         with:
           distribution: 'temurin'
           java-version: 11
       - name: Cache SonarCloud packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3 #https://github.com/actions/cache/releases
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3 #https://github.com/actions/cache/releases
         with:
           path: |
             ~/.gradle/caches
@@ -39,7 +39,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: ./gradlew clean build
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2 #https://github.com/actions/upload-artifact/releases
         with:
           name: Jar
           path: jar/build/libs/TAB-**.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - v3
+      - update-actions
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - v3
-      - update-actions
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
Update Actions to get rid of deprecation warnings
Also added links to their release pages as a comment to easily find their latest version in the future
![image](https://user-images.githubusercontent.com/65610536/213006880-f0ba6ad9-63ba-45fc-8312-1f20009f7a54.png)

Builds successfully without the warnings. [My Test Build](https://github.com/Chris6ix/TAB/actions/runs/3943041477).
