### PR TITLE
optimize

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/CpuManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/CpuManager.java
@@ -3,7 +3,6 @@ package me.neznamy.tab.shared;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.LongAdder;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -15,23 +14,33 @@ import me.neznamy.tab.api.feature.TabFeature;
  */
 public class CpuManager {
 
-    /** Data reset interval in milliseconds */
-    private final int BUFFER_SIZE_MILLIS = 10000;
+    /**
+     * Data reset interval in milliseconds
+     */
+    private static final int BUFFER_SIZE_MILLIS = 10000;
 
-    /** Active time in current time period saved as nanoseconds from features */
-    private volatile Map<String, Map<String, LongAdder>> featureUsageCurrent
+    /**
+     * Active time in current time period saved as nanoseconds from features
+     */
+    private volatile Map<String, Map<String, Long>> featureUsageCurrent
             = new ConcurrentHashMap<>();
 
-    /** Active time in current time period saved as nanoseconds from placeholders */
-    private volatile Map<String, LongAdder> placeholderUsageCurrent
+    /**
+     * Active time in current time period saved as nanoseconds from placeholders
+     */
+    private volatile Map<String, Long> placeholderUsageCurrent
             = new ConcurrentHashMap<>();
 
-    /** Active time in previous time period saved as nanoseconds from features */
-    private volatile Map<String, Map<String, LongAdder>> featureUsagePrevious
+    /**
+     * Active time in previous time period saved as nanoseconds from features
+     */
+    private volatile Map<String, Map<String, Long>> featureUsagePrevious
             = new HashMap<>();
 
-    /** Active time in previous time period saved as nanoseconds from placeholders */
-    private volatile Map<String, LongAdder> placeholderUsagePrevious
+    /**
+     * Active time in previous time period saved as nanoseconds from placeholders
+     */
+    private volatile Map<String, Long> placeholderUsagePrevious
             = new HashMap<>();
 
     // Scheduler for scheduling delayed and repeating tasks
@@ -62,8 +71,7 @@ public class CpuManager {
      * Submits task to TAB's main thread. If plugin is not enabled yet,
      * queues the task instead and executes once it's loaded.
      *
-     * @param   task
-     *          task to execute
+     * @param task task to execute
      */
     private void submit(Runnable task) {
         if (scheduler.isShutdown()) return;
@@ -79,7 +87,7 @@ public class CpuManager {
     /**
      * Returns cpu usage map of placeholders from previous time period
      *
-     * @return  cpu usage map of placeholders
+     * @return cpu usage map of placeholders
      */
     public Map<String, Float> getPlaceholderUsage() {
         return getUsage(placeholderUsagePrevious);
@@ -88,112 +96,72 @@ public class CpuManager {
     /**
      * Converts nano map to percent and sorts it from highest to lowest usage.
      *
-     * @param   map
-     *          map to convert
-     * @return  converted and sorted map
+     * @param map map to convert
+     * @return converted and sorted map
      */
-    private Map<String, Float> getUsage(Map<String, LongAdder> map) {
-        Map<String, Long> nanoMap = new HashMap<>();
-        String key;
-        for (Entry<String, LongAdder> nanos : map.entrySet()) {
-            key = nanos.getKey();
-            nanoMap.putIfAbsent(key, 0L);
-            nanoMap.put(key, nanoMap.get(key)+nanos.getValue().sum());
-        }
-        Map<String, Float> percentMap = new HashMap<>();
-        for (Entry<String, Long> entry : nanoMap.entrySet()) {
-            percentMap.put(entry.getKey(), nanosToPercent(entry.getValue()));
-        }
-        return sortByValue(percentMap);
+    private static Map<String, Float> getUsage(Map<String, Long> map) {
+        return map
+                .entrySet()
+                .stream()
+                .sorted(Entry.comparingByValue((o1, o2) -> Long.compare(o2, o1)))
+                .distinct()
+                .collect(LinkedHashMap::new,
+                        (m, e) -> m.put(e.getKey(), nanosToPercent(e.getValue())),
+                        Map::putAll
+                );
     }
 
     /**
      * Returns map of CPU usage per feature and type in the previous time period
      *
-     * @return  map of CPU usage per feature and type
+     * @return map of CPU usage per feature and type
      */
     public Map<String, Map<String, Float>> getFeatureUsage() {
-        Map<String, Map<String, Long>> total = new HashMap<>();
-        for (Entry<String, Map<String, LongAdder>> nanos : featureUsagePrevious.entrySet()) {
-            String key = nanos.getKey();
-            total.putIfAbsent(key, new HashMap<>());
-            Map<String, Long> usage = total.get(key);
-            for (Entry<String, LongAdder> entry : nanos.getValue().entrySet()) {
-                usage.putIfAbsent(entry.getKey(), 0L);
-                usage.put(entry.getKey(), usage.get(entry.getKey()) + entry.getValue().sum());
-            }
-        }
-        Map<String, Map<String, Float>> sorted = new LinkedHashMap<>();
-        for (String key : sortKeys(total)) {
-            Map<String, Long> local = sortByValue(total.get(key));
-            Map<String, Float> percent = new LinkedHashMap<>();
-            for (Entry<String, Long> entry : local.entrySet()) {
-                percent.put(entry.getKey(), nanosToPercent(entry.getValue()));
-            }
-            sorted.put(key, percent);
-        }
-        return sorted;
+        final Map<String, Map<String, Long>> map = featureUsagePrevious;
+
+        TreeMap<Long, Map.Entry<String, Map<String, Float>>> sorted
+                = new TreeMap<>((o1, o2) -> Long.compare(o2, o1));
+
+        map.forEach((key, val) -> {
+            Set<Map.Entry<String, Long>> entries = val.entrySet();
+            Map<String, Float> percent = new LinkedHashMap<>(entries.size());
+            long sum = entries
+                    .stream()
+                    .sorted(Map.Entry.comparingByValue((o1, o2) -> Long.compare(o2, o1)))
+                    .distinct()
+                    .peek(e -> percent.put(e.getKey(), nanosToPercent(e.getValue())))
+                    .mapToLong(Map.Entry::getValue)
+                    .sum();
+            sorted.put(sum, // Map.entry(key, percent) inline type java9+
+                    new AbstractMap.SimpleImmutableEntry<>(key, percent));
+        });
+        // we will also try to get rid of O(log(n)) for random reading
+        int assumeCapacity = map.size();
+        return sorted
+                .values()
+                .stream()
+                .collect(() -> new LinkedHashMap<>(assumeCapacity),
+                        (m, e) -> m.put(e.getKey(), e.getValue()),
+                        Map::putAll
+                );
     }
 
     /**
      * Converts nanoseconds to percent usage.
      *
-     * @param   nanos
-     *          nanoseconds of cpu time
-     * @return  usage in % (0-100)
+     * @param nanos nanoseconds of cpu time
+     * @return usage in % (0-100)
      */
-    private float nanosToPercent(long nanos) {
-        float percent = (float) nanos / BUFFER_SIZE_MILLIS / 1000000; //relative usage (0-1)
-        percent *= 100; //relative into %
-        return percent;
-    }
-
-    /**
-     * Sorts map by value from highest to lowest
-     *
-     * @param   <K>
-     *          map key type
-     * @param   <V>
-     *          map value type
-     * @param   map
-     *          map to sort
-     * @return  sorted map
-     */
-    private <K, V extends Comparable<V>> Map<K, V> sortByValue(Map<K, V> map) {
-        Comparator<K> valueComparator = (k1, k2) -> {
-            int diff = map.get(k2).compareTo(map.get(k1));
-            return diff == 0 ? 1 : diff; //otherwise, entries with duplicate values are lost
-        };
-        Map<K, V> sortedByValues = new TreeMap<>(valueComparator);
-        sortedByValues.putAll(map);
-        return sortedByValues;
-    }
-
-    /**
-     * Sorts keys by map nested values from highest to lowest and returns sorted list of keys
-     * @param   <K>
-     *          map key type
-     * @param   map
-     *          map to sort
-     * @return  list of keys sorted from the highest map value to lowest
-     */
-    private <K> List<K> sortKeys(Map<K, Map<String, Long>> map) {
-        Map<K, Long> simplified = new LinkedHashMap<>();
-        for (Entry<K, Map<String, Long>> entry : map.entrySet()) {
-            simplified.put(entry.getKey(), entry.getValue().values().stream().mapToLong(Long::longValue).sum());
-        }
-        return new ArrayList<>(sortByValue(simplified).keySet());
+    private static float nanosToPercent(long nanos) {
+        return TimeUnit.SECONDS.toNanos(nanos);
     }
 
     /**
      * Adds cpu time to specified feature and usage type
      *
-     * @param   feature
-     *          feature to add time to
-     * @param   type
-     *          sub-feature to add time to
-     * @param   nanoseconds
-     *          time to add
+     * @param feature     feature to add time to
+     * @param type        sub-feature to add time to
+     * @param nanoseconds time to add
      */
     public void addTime(TabFeature feature, String type, long nanoseconds) {
         addTime(feature.getFeatureName(), type, nanoseconds);
@@ -202,40 +170,32 @@ public class CpuManager {
     /**
      * Adds cpu time to specified feature and usage type
      *
-     * @param   feature
-     *          feature to add time to
-     * @param   type
-     *          sub-feature to add time to
-     * @param   nanoseconds
-     *          time to add
+     * @param feature     feature to add time to
+     * @param type        sub-feature to add time to
+     * @param nanoseconds time to add
      */
     public void addTime(String feature, String type, long nanoseconds) {
         featureUsageCurrent
                 .computeIfAbsent(feature, f -> new ConcurrentHashMap<>())
-                .computeIfAbsent(type, t -> new LongAdder()).add(nanoseconds);
+                .merge(type, nanoseconds, (k,v) -> v + nanoseconds);
     }
 
     /**
      * Adds used time to specified key into specified map
      *
-     * @param   map
-     *          map to add usage to
-     * @param   key
-     *          usage key
-     * @param   time
-     *          nanoseconds to add
+     * @param map  map to add usage to
+     * @param key  usage key
+     * @param time nanoseconds to add
      */
-    private void addTime(Map<String, LongAdder> map, String key, long time) {
-        map.computeIfAbsent(key, k -> new LongAdder()).add(time);
+    private static void addTime(Map<String, Long> map, String key, long time) {
+        map.merge(key, time, (k,v) -> v + time);
     }
 
     /**
      * Adds placeholder time to specified placeholder
      *
-     * @param   placeholder
-     *          placeholder to add time to
-     * @param   nanoseconds
-     *          time to add
+     * @param placeholder placeholder to add time to
+     * @param nanoseconds time to add
      */
     public void addPlaceholderTime(String placeholder, long nanoseconds) {
         addTime(placeholderUsageCurrent, placeholder, nanoseconds);
@@ -249,7 +209,7 @@ public class CpuManager {
         submit(() -> {
             long time = System.nanoTime();
             task.run();
-            addTime(feature, type, System.nanoTime()-time);
+            addTime(feature, type, System.nanoTime() - time);
         });
     }
 


### PR DESCRIPTION
made several "optimizations"

in the previous PR, I changed AtomicLong to LongAdder because we had a lot of writers, in this case, when we have no competition for writers (we write only in one thread), LongAdder can, on the contrary, reduce performance and increase memory consumption

in CHM merge/compute guarantees an atomic change, so I moved the long modification to a lambda

You also had something terrible in the sorting of cards, I even tested it a little and benchmarked it (for comparison):

```
newGetFeatureUsage 184645,277 ops/s
oldGetFeatureUsage     61757,728 ops/s
```

