### PR TITLE
Fix ViaVersion bug returning -1 version

### DIFF
--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/BukkitEventListener.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/BukkitEventListener.java
@@ -21,7 +21,7 @@ public class BukkitEventListener extends EventListener<Player> implements Listen
         quit(e.getPlayer().getUniqueId());
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOW)
     public void onJoin(PlayerJoinEvent e) {
         join(e.getPlayer());
     }


### PR DESCRIPTION
Explanation:

Both TAB and ViaVersion PlayerJoinEvent priority are LOWEST and seems that TAB registers earlier than ViaVersion the listeners, this causes TAB not being able to get the client protocol version due to ViaVersion not being able to register it firstly.

There might be another way to workaround this since i don't know changing the priority would cause any issue with TAB itself.