### PR TITLE
Added support for different default skins depending on the slot index in the layout feature

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/FixedSlot.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/FixedSlot.java
@@ -79,7 +79,7 @@ public class FixedSlot extends TabFeature implements Refreshable {
                 manager.getUUID(slot),
                 text,
                 "Layout-" + pattern.getName() + "-SLOT-" + slot,
-                skin.length() == 0 ? manager.getDefaultSkin() : skin,
+                skin.length() == 0 ? manager.getDefaultSkin(slot) : skin,
                 "Layout-" + pattern.getName() + "-SLOT-" + slot + "-skin",
                 ping
         );

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
@@ -14,7 +14,6 @@ import me.neznamy.tab.shared.chat.EnumChatFormat;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.config.file.ConfigurationFile;
-import me.neznamy.tab.shared.platform.TabList;
 import me.neznamy.tab.shared.platform.TabPlayer;
 import me.neznamy.tab.shared.features.PlayerList;
 import me.neznamy.tab.shared.features.layout.skin.SkinManager;

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutPattern.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutPattern.java
@@ -77,7 +77,7 @@ public class LayoutPattern extends TabFeature implements Refreshable, Layout {
 
     @Override
     public void addFixedSlot(int slot, @NonNull String text) {
-        addFixedSlot(slot, text, manager.getDefaultSkin(), manager.getEmptySlotPing());
+        addFixedSlot(slot, text, manager.getDefaultSkin(slot), manager.getEmptySlotPing());
     }
 
     @Override
@@ -87,7 +87,7 @@ public class LayoutPattern extends TabFeature implements Refreshable, Layout {
 
     @Override
     public void addFixedSlot(int slot, @NonNull String text, int ping) {
-        addFixedSlot(slot, text, manager.getDefaultSkin(), ping);
+        addFixedSlot(slot, text, manager.getDefaultSkin(slot), ping);
     }
 
     @Override

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutView.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutView.java
@@ -50,7 +50,7 @@ public class LayoutView {
             viewer.getTabList().addEntry(slot.createEntry(viewer));
         }
         for (int slot : emptySlots) {
-            viewer.getTabList().addEntry(new TabList.Entry(manager.getUUID(slot), getEntryName(viewer, slot), manager.getSkinManager().getDefaultSkin(),
+            viewer.getTabList().addEntry(new TabList.Entry(manager.getUUID(slot), getEntryName(viewer, slot), manager.getSkinManager().getDefaultSkin(slot),
                     manager.getEmptySlotPing(), 0, new IChatBaseComponent("")));
         }
         tick();

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/ParentGroup.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/ParentGroup.java
@@ -23,7 +23,7 @@ public class ParentGroup {
         this.slots = pattern.getSlots();
         this.viewer = viewer;
         for (int slot : slots) {
-            playerSlots.put(slot, new PlayerSlot(layout, layout.getManager().getUUID(slot)));
+            playerSlots.put(slot, new PlayerSlot(slot, layout, layout.getManager().getUUID(slot)));
         }
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/PlayerSlot.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/PlayerSlot.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class PlayerSlot {
 
+    private final int slot;
     private final LayoutView layout;
     @Getter private final UUID uniqueId;
     @Getter private TabPlayer player;
@@ -45,7 +46,7 @@ public class PlayerSlot {
             data = new TabList.Entry(
                     uniqueId,
                     layout.getEntryName(p, uniqueId.getLeastSignificantBits()),
-                    layout.getManager().getSkinManager().getDefaultSkin(),
+                    layout.getManager().getSkinManager().getDefaultSkin(slot),
                     layout.getManager().getEmptySlotPing(),
                     0,
                     new IChatBaseComponent(text)

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SkinManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SkinManager.java
@@ -20,9 +20,16 @@ public class SkinManager {
 
     private final List<String> invalidSkins = new ArrayList<>();
     @Getter private TabList.Skin defaultSkin;
+    private final Map<Integer, TabList.Skin> defaultSkinHashMap = new HashMap<>();
     private final Map<String, SkinSource> sources = new HashMap<>();
 
-    public SkinManager(@NotNull String defaultSkin) {
+    public TabList.Skin getDefaultSkin(int slot) {
+        if(defaultSkinHashMap.containsKey(slot))
+                return defaultSkinHashMap.get(slot);
+        return defaultSkin;
+    }
+
+    public SkinManager(@NotNull String defaultSkin, Map<Integer, String> defaultSkinHashMap) {
         try {
             File f = new File(TAB.getInstance().getDataFolder(), "skincache.yml");
             if (f.exists() || f.createNewFile()) {
@@ -31,6 +38,10 @@ public class SkinManager {
                 sources.put("mineskin", new MineSkin(cache));
                 sources.put("texture", new Texture(cache));
                 this.defaultSkin = getSkin(defaultSkin);
+                for ( Map.Entry<Integer, String> entry : defaultSkinHashMap.entrySet()) {
+                    this.defaultSkinHashMap.put(entry.getKey(), getSkin(entry.getValue()));
+                }
+                System.out.println(this.defaultSkinHashMap);
             } else {
                 TAB.getInstance().getErrorManager().criticalError("Failed to load skin cache", null);
             }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SkinManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SkinManager.java
@@ -41,7 +41,6 @@ public class SkinManager {
                 for ( Map.Entry<Integer, String> entry : defaultSkinHashMap.entrySet()) {
                     this.defaultSkinHashMap.put(entry.getKey(), getSkin(entry.getValue()));
                 }
-                System.out.println(this.defaultSkinHashMap);
             } else {
                 TAB.getInstance().getErrorManager().criticalError("Failed to load skin cache", null);
             }


### PR DESCRIPTION
I have added support for different default skins depending on the slot index to allow you to customize the tab list even further.  If a slot doesn't have a default skin specified "layout.default-skin" will be used as before.

Here is an example of what a configuration with different default-skins could look like.
```yaml
default-skins:
    green:
      slots:
        - 0-40
      skin: mineskin:dd999400b7eb42288d62f8066a74f2b8
    yellow:
      slots: 
        - 41-60
      skin: mineskin:20f93edf53784fdc96e62affc9b7087e
    red:
      slots: 
        - 61-80
      skin: mineskin:7bc1ef76b2cc41b59067ca409be76e5a

  default-skin: mineskin:dd999400b7eb42288d62f8066a74f2b8
```

With this added functionality you can make something like this:
![image](https://github.com/NEZNAMY/TAB/assets/75088349/309b6f1c-a5e5-4798-9f9f-f7855d4549b2)

