### PR TITLE
Added support for PremiumVanishAPI

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -10,4 +10,5 @@ dependencies {
     compileOnly("LibsDisguises:LibsDisguises:10.0.21") {
         exclude("org.spigotmc", "spigot")
     }
+    compileOnly("com.github.LeonMangler:PremiumVanishAPI:2.8.8")
 }

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/features/premiumvanish/BukkitPremiumVanishSupport.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/features/premiumvanish/BukkitPremiumVanishSupport.java
@@ -1,0 +1,20 @@
+package me.neznamy.tab.platforms.bukkit.features.premiumvanish;
+
+import de.myzelyam.api.vanish.VanishAPI;
+import me.neznamy.tab.api.TabPlayer;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
+import org.bukkit.entity.Player;
+
+/**
+ * PremiumVanishSupport implementation for Bukkit
+ */
+public class BukkitPremiumVanishSupport extends PremiumVanishSupport {
+    @Override
+    public boolean canSee(TabPlayer viewer, TabPlayer viewed)
+    {
+        Player viewerPlayer = (Player)viewer.getPlayer();
+        Player viewedPlayer = (Player)viewed.getPlayer();
+
+        return VanishAPI.canSee(viewerPlayer, viewedPlayer);
+    }
+}

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
@@ -4,23 +4,25 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import me.clip.placeholderapi.PlaceholderAPI;
 import me.neznamy.tab.platforms.bukkit.*;
-import me.neznamy.tab.shared.GroupManager;
-import me.neznamy.tab.shared.ProtocolVersion;
-import me.neznamy.tab.shared.TabConstants;
-import me.neznamy.tab.shared.chat.EnumChatFormat;
-import me.neznamy.tab.shared.chat.IChatBaseComponent;
-import me.neznamy.tab.shared.features.injection.PipelineInjector;
-import me.neznamy.tab.shared.features.types.TabFeature;
+import me.neznamy.tab.platforms.bukkit.features.BukkitNameTagX;
 import me.neznamy.tab.platforms.bukkit.features.BukkitTabExpansion;
 import me.neznamy.tab.platforms.bukkit.features.PerWorldPlayerList;
 import me.neznamy.tab.platforms.bukkit.features.WitherBossBar;
-import me.neznamy.tab.platforms.bukkit.features.BukkitNameTagX;
+import me.neznamy.tab.platforms.bukkit.features.premiumvanish.BukkitPremiumVanishSupport;
 import me.neznamy.tab.platforms.bukkit.nms.NMSStorage;
+import me.neznamy.tab.shared.GroupManager;
+import me.neznamy.tab.shared.ProtocolVersion;
 import me.neznamy.tab.shared.TAB;
+import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.backend.BackendPlatform;
+import me.neznamy.tab.shared.chat.EnumChatFormat;
+import me.neznamy.tab.shared.chat.IChatBaseComponent;
 import me.neznamy.tab.shared.features.PlaceholderManagerImpl;
 import me.neznamy.tab.shared.features.bossbar.BossBarManagerImpl;
+import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.nametags.NameTag;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
+import me.neznamy.tab.shared.features.types.TabFeature;
 import me.neznamy.tab.shared.hook.LuckPermsHook;
 import me.neznamy.tab.shared.placeholders.PlayerPlaceholderImpl;
 import me.neznamy.tab.shared.placeholders.expansion.EmptyTabExpansion;
@@ -137,6 +139,16 @@ public class BukkitPlatform implements BackendPlatform {
     @Nullable
     public TabFeature getPerWorldPlayerList() {
         return new PerWorldPlayerList(plugin);
+    }
+
+    @Override
+    @Nullable
+    public PremiumVanishSupport getPremiumVanishSupport() {
+        if(plugin.getServer().getPluginManager().isPluginEnabled("PremiumVanish"))
+        {
+            return new BukkitPremiumVanishSupport();
+        }
+        return null;
     }
 
     @Override

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
@@ -2,12 +2,14 @@ package me.neznamy.tab.platforms.bungeecord;
 
 import com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI;
 import lombok.AllArgsConstructor;
+import me.neznamy.tab.platforms.bungeecord.features.BungeePremiumVanishSupport;
 import me.neznamy.tab.platforms.bungeecord.features.BungeeRedisSupport;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.EnumChatFormat;
 import me.neznamy.tab.shared.chat.IChatBaseComponent;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.hook.ViaVersionHook;
 import me.neznamy.tab.shared.proxy.ProxyPlatform;
@@ -44,6 +46,16 @@ public class BungeePlatform extends ProxyPlatform {
         if (ReflectionUtils.classExists("com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI") &&
                 RedisBungeeAPI.getRedisBungeeApi() != null) {
             return new BungeeRedisSupport(plugin);
+        }
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public PremiumVanishSupport getPremiumVanishSupport() {
+        if(plugin.getProxy().getPluginManager().getPlugin("PremiumVanish") != null)
+        {
+            return new BungeePremiumVanishSupport();
         }
         return null;
     }

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/features/BungeePremiumVanishSupport.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/features/BungeePremiumVanishSupport.java
@@ -1,0 +1,26 @@
+package me.neznamy.tab.platforms.bungeecord.features;
+
+import de.myzelyam.api.vanish.BungeeVanishAPI;
+import me.neznamy.tab.shared.TAB;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+
+/**
+ * PremiumVanishSupport implementation for Velocity
+ */
+public class BungeePremiumVanishSupport extends PremiumVanishSupport {
+    @Override
+    public boolean canSee(Object viewerObj, Object viewedObj)
+    {
+        if(viewerObj instanceof ProxiedPlayer && viewedObj instanceof ProxiedPlayer)
+        {
+            ProxiedPlayer viewer = (ProxiedPlayer)viewerObj;
+            ProxiedPlayer viewed = (ProxiedPlayer)viewedObj;
+
+            return BungeeVanishAPI.canSee(viewer, viewed);
+        }
+
+        TAB.getInstance().getErrorManager().printError("ERROR: Invalid instance!");
+        return true;
+    }
+}

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/features/BungeePremiumVanishSupport.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/features/BungeePremiumVanishSupport.java
@@ -1,7 +1,7 @@
 package me.neznamy.tab.platforms.bungeecord.features;
 
 import de.myzelyam.api.vanish.BungeeVanishAPI;
-import me.neznamy.tab.shared.TAB;
+import me.neznamy.tab.api.TabPlayer;
 import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
@@ -10,17 +10,11 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
  */
 public class BungeePremiumVanishSupport extends PremiumVanishSupport {
     @Override
-    public boolean canSee(Object viewerObj, Object viewedObj)
+    public boolean canSee(TabPlayer viewer, TabPlayer viewed)
     {
-        if(viewerObj instanceof ProxiedPlayer && viewedObj instanceof ProxiedPlayer)
-        {
-            ProxiedPlayer viewer = (ProxiedPlayer)viewerObj;
-            ProxiedPlayer viewed = (ProxiedPlayer)viewedObj;
+        ProxiedPlayer viewerPlayer = (ProxiedPlayer)viewer.getPlayer();
+        ProxiedPlayer viewedPlayer = (ProxiedPlayer)viewed.getPlayer();
 
-            return BungeeVanishAPI.canSee(viewer, viewed);
-        }
-
-        TAB.getInstance().getErrorManager().printError("ERROR: Invalid instance!");
-        return true;
+        return BungeeVanishAPI.canSee(viewerPlayer, viewedPlayer);
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
@@ -18,6 +18,7 @@ import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.layout.LayoutManagerImpl;
 import me.neznamy.tab.shared.features.nametags.NameTag;
 import me.neznamy.tab.shared.features.nametags.unlimited.NameTagX;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.features.scoreboard.ScoreboardManagerImpl;
 import me.neznamy.tab.shared.features.sorting.Sorting;
@@ -397,6 +398,12 @@ public class FeatureManager {
         // Must be loaded after: Global PlayerList, PlayerList, NameTags, YellowNumber, BelowName
         RedisSupport redis = TAB.getInstance().getPlatform().getRedisSupport();
         if (redis != null) TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.REDIS_BUNGEE, redis);
+
+        // PremiumVanish API
+        PremiumVanishSupport premiumVanish = TAB.getInstance().getPlatform().getPremiumVanishSupport();
+        if (premiumVanish != null) {
+            TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.PREMIUMVANISH, premiumVanish);
+        }
 
         featureManager.registerFeature(TabConstants.Feature.NICK_COMPATIBILITY, new NickCompatibility());
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/TabConstants.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/TabConstants.java
@@ -195,6 +195,7 @@ public class TabConstants {
         public static final String UNLIMITED_NAME_TAGS_PACKET_LISTENER = "nametagx-packet";
         public static final String UNLIMITED_NAME_TAGS_VEHICLE_REFRESHER = "nametagx-vehicle";
         public static final String PING_SPOOF = "PingSpoof";
+        public static final String PREMIUMVANISH = "PremiumVanish";
 
         //Bukkit only
         public static final String PER_WORLD_PLAYER_LIST = "PerWorldPlayerList";

--- a/shared/src/main/java/me/neznamy/tab/shared/backend/BackendPlatform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/backend/BackendPlatform.java
@@ -4,6 +4,7 @@ import me.neznamy.tab.api.placeholder.PlaceholderManager;
 import me.neznamy.tab.shared.GroupManager;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 import me.neznamy.tab.shared.hook.LuckPermsHook;
 import me.neznamy.tab.shared.placeholders.UniversalPlaceholderRegistry;
 import me.neznamy.tab.shared.platform.Platform;
@@ -21,6 +22,7 @@ public interface BackendPlatform extends Platform {
     }
 
     default RedisSupport getRedisSupport() { return null; }
+    default PremiumVanishSupport getPremiumVanishSupport() { return null; }
 
     @Override
     default void registerPlaceholders() {

--- a/shared/src/main/java/me/neznamy/tab/shared/features/alignedplayerlist/PlayerView.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/alignedplayerlist/PlayerView.java
@@ -44,7 +44,7 @@ public class PlayerView {
         if (viewer.getVersion().getMinorVersion() < 8) return;
         int width = getPlayerNameWidth(connectedPlayer);
         playerWidths.put(connectedPlayer, width);
-        if (width > maxWidth && (!connectedPlayer.isVanished() || canSeeVanished || (premiumVanish != null && premiumVanish.canSee(viewer.getPlayer(), connectedPlayer.getPlayer())))) {
+        if (width > maxWidth && (!connectedPlayer.isVanished() || canSeeVanished || (premiumVanish != null && premiumVanish.canSee(viewer, connectedPlayer)))) {
             maxWidth = width;
             maxPlayer = connectedPlayer;
             updateAllPlayers();
@@ -72,7 +72,7 @@ public class PlayerView {
         String prefixAndName = prefixPr.getFormat(viewer) + namePr.getFormat(viewer);
         String suffix = suffixPr.getFormat(viewer);
         if (suffix.length() == 0) return IChatBaseComponent.optimizedComponent(prefixAndName);
-        if ((target.isVanished() && !canSeeVanished && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), target.getPlayer()))) || width > maxWidth) {
+        if ((target.isVanished() && !canSeeVanished && (premiumVanish == null || !premiumVanish.canSee(viewer, target))) || width > maxWidth) {
             //tab sending packets for vanished players or player just unvanished
             return IChatBaseComponent.optimizedComponent(prefixAndName + suffix);
         }
@@ -187,7 +187,7 @@ public class PlayerView {
         TabPlayer newMaxPlayer = null;
         for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
             if (all == ignoredPlayer || !playerWidths.containsKey(all)) continue;
-            if (all.isVanished() && !canSeeVanished && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), all.getPlayer())) && all != viewer) continue;
+            if (all.isVanished() && !canSeeVanished && (premiumVanish == null || !premiumVanish.canSee(viewer, all)) && all != viewer) continue;
             int localWidth = playerWidths.get(all);
             if (localWidth > newMaxWidth) {
                 newMaxWidth = localWidth;

--- a/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
@@ -5,6 +5,7 @@ import java.util.*;
 import lombok.Getter;
 import me.neznamy.tab.shared.chat.IChatBaseComponent;
 import me.neznamy.tab.shared.TabConstants;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 import me.neznamy.tab.shared.platform.TabList;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.platform.TabPlayer;
@@ -26,6 +27,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
     private final boolean isolateUnlistedServers = TAB.getInstance().getConfiguration().getConfig().getBoolean("global-playerlist.isolate-unlisted-servers", false);
 
     private final PlayerList playerlist = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PLAYER_LIST);
+    private final PremiumVanishSupport premiumVanish = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PREMIUMVANISH);
     @Getter private final String featureName = "Global PlayerList";
 
     public GlobalPlayerList() {
@@ -50,7 +52,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
 
     public boolean shouldSee(@NotNull TabPlayer viewer, @NotNull TabPlayer displayed) {
         if (displayed == viewer) return true;
-        if (displayed.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED)) return false;
+        if (displayed.isVanished() && (!viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), displayed.getPlayer())))) return false;
         if (isSpyServer(viewer.getServer())) return true;
         return getServerGroup(viewer.getServer()).equals(getServerGroup(displayed.getServer()));
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
@@ -52,7 +52,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
 
     public boolean shouldSee(@NotNull TabPlayer viewer, @NotNull TabPlayer displayed) {
         if (displayed == viewer) return true;
-        if (displayed.isVanished() && (!viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), displayed.getPlayer())))) return false;
+        if (displayed.isVanished() && (!viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer, displayed)))) return false;
         if (isSpyServer(viewer.getServer())) return true;
         return getServerGroup(viewer.getServer()).equals(getServerGroup(displayed.getServer()));
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
@@ -14,6 +14,7 @@ import me.neznamy.tab.shared.chat.EnumChatFormat;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.config.file.ConfigurationFile;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 import me.neznamy.tab.shared.platform.TabPlayer;
 import me.neznamy.tab.shared.features.PlayerList;
 import me.neznamy.tab.shared.features.layout.skin.SkinManager;
@@ -49,6 +50,7 @@ public class LayoutManagerImpl extends TabFeature implements LayoutManager, Join
     private final String refreshDisplayName = "Switching layouts";
     private final WeakHashMap<TabPlayer, LayoutView> views = new WeakHashMap<>();
     private final WeakHashMap<me.neznamy.tab.api.TabPlayer, LayoutPattern> forcedLayouts = new WeakHashMap<>();
+    private PremiumVanishSupport premiumVanish;
 
     private static boolean teamsEnabled;
 
@@ -84,6 +86,7 @@ public class LayoutManagerImpl extends TabFeature implements LayoutManager, Join
         for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
             onJoin(p);
         }
+        premiumVanish = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PREMIUMVANISH);
     }
 
     private @NotNull Direction parseDirection(@NotNull String value) {

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutView.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutView.java
@@ -71,7 +71,7 @@ public class LayoutView {
 
         if(manager.getPremiumVanish() != null)
         {
-            str = str.filter(player -> !player.isVanished() || manager.getPremiumVanish().canSee(viewer.getPlayer(), player.getPlayer()));
+            str = str.filter(player -> !player.isVanished() || manager.getPremiumVanish().canSee(viewer, player));
         }
         else if (!viewer.hasPermission(TabConstants.Permission.SEE_VANISHED)) {
             str = str.filter(player -> !player.isVanished());

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutView.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutView.java
@@ -68,9 +68,15 @@ public class LayoutView {
 
     public void tick() {
         Stream<TabPlayer> str = manager.getSortedPlayers().keySet().stream();
-        if (!viewer.hasPermission(TabConstants.Permission.SEE_VANISHED)) {
+
+        if(manager.getPremiumVanish() != null)
+        {
+            str = str.filter(player -> !player.isVanished() || manager.getPremiumVanish().canSee(viewer.getPlayer(), player.getPlayer()));
+        }
+        else if (!viewer.hasPermission(TabConstants.Permission.SEE_VANISHED)) {
             str = str.filter(player -> !player.isVanished());
         }
+
         List<TabPlayer> players = str.collect(Collectors.toList());
         for (ParentGroup group : groups) {
             group.tick(players);

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
@@ -125,7 +125,7 @@ public class NameTag extends TabFeature implements NameTagManager, JoinListener,
         if (!disableChecker.isDisabledPlayer(disconnectedPlayer) && !hasTeamHandlingPaused(disconnectedPlayer)) {
             for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
                 if (viewer == disconnectedPlayer) continue; //player who just disconnected
-                if (disconnectedPlayer.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), disconnectedPlayer.getPlayer()))) continue;
+                if (disconnectedPlayer.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer, disconnectedPlayer))) continue;
                 viewer.getScoreboard().unregisterTeam(sorting.getShortTeamName(disconnectedPlayer));
             }
         }
@@ -232,7 +232,7 @@ public class NameTag extends TabFeature implements NameTagManager, JoinListener,
     }
 
     public void updateTeamData(@NonNull TabPlayer p, @NonNull TabPlayer viewer) {
-        if (p.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), p.getPlayer()))) return;
+        if (p.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer, p))) return;
         boolean visible = getTeamVisibility(p, viewer);
         String currentPrefix = p.getProperty(TabConstants.Property.TAGPREFIX).getFormat(viewer);
         String currentSuffix = p.getProperty(TabConstants.Property.TAGSUFFIX).getFormat(viewer);
@@ -249,7 +249,7 @@ public class NameTag extends TabFeature implements NameTagManager, JoinListener,
     public void unregisterTeam(@NonNull TabPlayer p, @NonNull String teamName) {
         if (hasTeamHandlingPaused(p)) return;
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (p.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), p.getPlayer()))) continue;
+            if (p.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer, p))) continue;
             viewer.getScoreboard().unregisterTeam(teamName);
         }
     }
@@ -262,7 +262,7 @@ public class NameTag extends TabFeature implements NameTagManager, JoinListener,
 
     private void registerTeam(@NonNull TabPlayer p, @NonNull TabPlayer viewer) {
         if (hasTeamHandlingPaused(p)) return;
-        if (p.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), p.getPlayer()))) return;
+        if (p.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer, p))) return;
         String replacedPrefix = p.getProperty(TabConstants.Property.TAGPREFIX).getFormat(viewer);
         String replacedSuffix = p.getProperty(TabConstants.Property.TAGSUFFIX).getFormat(viewer);
         viewer.getScoreboard().registerTeam(
@@ -357,7 +357,7 @@ public class NameTag extends TabFeature implements NameTagManager, JoinListener,
     @Override
     public void onVanishStatusChange(@NotNull TabPlayer player) {
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (player.isVanished() && (!viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer.getPlayer(), player.getPlayer())))) {
+            if (player.isVanished() && (!viewer.hasPermission(TabConstants.Permission.SEE_VANISHED) && (premiumVanish == null || !premiumVanish.canSee(viewer, player)))) {
                 viewer.getScoreboard().unregisterTeam(sorting.getShortTeamName(player));
             } else {
                 registerTeam(player, viewer);

--- a/shared/src/main/java/me/neznamy/tab/shared/features/premiumvanish/PremiumVanishSupport.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/premiumvanish/PremiumVanishSupport.java
@@ -1,0 +1,25 @@
+package me.neznamy.tab.shared.features.premiumvanish;
+
+import me.neznamy.tab.shared.features.types.TabFeature;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Feature using PremiumVanishAPI to check
+ * if a player can see each other
+ */
+public abstract class PremiumVanishSupport extends TabFeature
+{
+    /**
+     * @return Boolean if viewer can see viewed
+     */
+    public boolean canSee(Object viewer, Object viewed)
+    {
+        return false;
+    }
+
+    @Override
+    @NotNull
+    public String getFeatureName() {
+        return "PremiumVanishSupport";
+    }
+}

--- a/shared/src/main/java/me/neznamy/tab/shared/features/premiumvanish/PremiumVanishSupport.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/premiumvanish/PremiumVanishSupport.java
@@ -1,5 +1,6 @@
 package me.neznamy.tab.shared.features.premiumvanish;
 
+import me.neznamy.tab.api.TabPlayer;
 import me.neznamy.tab.shared.features.types.TabFeature;
 import org.jetbrains.annotations.NotNull;
 
@@ -12,7 +13,7 @@ public abstract class PremiumVanishSupport extends TabFeature
     /**
      * @return Boolean if viewer can see viewed
      */
-    public boolean canSee(Object viewer, Object viewed)
+    public boolean canSee(TabPlayer viewer, TabPlayer viewed)
     {
         return false;
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
@@ -6,6 +6,7 @@ import me.neznamy.tab.shared.chat.IChatBaseComponent;
 import me.neznamy.tab.shared.features.bossbar.BossBarManagerImpl;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.nametags.NameTag;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.features.types.TabFeature;
 import me.neznamy.tab.shared.placeholders.expansion.TabExpansion;
@@ -83,6 +84,13 @@ public interface Platform {
      * @return  Created instance
      */
     @Nullable RedisSupport getRedisSupport();
+
+    /**
+     * Creates PremiumVanish feature and returns it
+     *
+     * @return  Created instance
+     */
+    @Nullable PremiumVanishSupport getPremiumVanishSupport();
 
     /**
      * Returns per world player list feature handler.

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     compileOnly("com.github.limework.redisbungee:RedisBungee-Velocity:0.11.0")
     compileOnly("com.velocitypowered:velocity-api:3.1.2-SNAPSHOT")
     annotationProcessor("com.velocitypowered:velocity-api:3.1.2-SNAPSHOT")
+    compileOnly("com.github.LeonMangler:PremiumVanishAPI:2.9.0-4")
 }
 
 tasks.compileJava {

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
@@ -6,12 +6,14 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import me.neznamy.tab.platforms.velocity.features.VelocityPremiumVanishSupport;
 import me.neznamy.tab.platforms.velocity.features.VelocityRedisSupport;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.EnumChatFormat;
 import me.neznamy.tab.shared.chat.IChatBaseComponent;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.proxy.ProxyPlatform;
 import me.neznamy.tab.shared.util.ReflectionUtils;
@@ -47,6 +49,17 @@ public class VelocityPlatform extends ProxyPlatform {
         if (ReflectionUtils.classExists("com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI") &&
                 RedisBungeeAPI.getRedisBungeeApi() != null) {
             return new VelocityRedisSupport(plugin);
+        }
+        return null;
+    }
+
+    @Override
+    @Nullable
+    public PremiumVanishSupport getPremiumVanishSupport()
+    {
+        if(plugin.getServer().getPluginManager().isLoaded("premiumvanish"))
+        {
+            return new VelocityPremiumVanishSupport();
         }
         return null;
     }

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/features/VelocityPremiumVanishSupport.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/features/VelocityPremiumVanishSupport.java
@@ -2,26 +2,19 @@ package me.neznamy.tab.platforms.velocity.features;
 
 import com.velocitypowered.api.proxy.Player;
 import de.myzelyam.api.vanish.VelocityVanishAPI;
-import me.neznamy.tab.shared.TAB;
+import me.neznamy.tab.api.TabPlayer;
 import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
 
 /**
  * PremiumVanishSupport implementation for Velocity
  */
-public class VelocityPremiumVanishSupport extends PremiumVanishSupport
-{
+public class VelocityPremiumVanishSupport extends PremiumVanishSupport {
     @Override
-    public boolean canSee(Object viewerObj, Object viewedObj)
+    public boolean canSee(TabPlayer viewer, TabPlayer viewed)
     {
-        if(viewerObj instanceof Player && viewedObj instanceof Player)
-        {
-            Player viewer = (Player)viewerObj;
-            Player viewed = (Player)viewedObj;
+        Player viewerPlayer = (Player)viewer.getPlayer();
+        Player viewedPlayer = (Player)viewed.getPlayer();
 
-            return VelocityVanishAPI.canSee(viewer, viewed);
-        }
-
-        TAB.getInstance().getErrorManager().printError("ERROR: Invalid instance!");
-        return true;
+        return VelocityVanishAPI.canSee(viewerPlayer, viewedPlayer);
     }
 }

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/features/VelocityPremiumVanishSupport.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/features/VelocityPremiumVanishSupport.java
@@ -1,0 +1,27 @@
+package me.neznamy.tab.platforms.velocity.features;
+
+import com.velocitypowered.api.proxy.Player;
+import de.myzelyam.api.vanish.VelocityVanishAPI;
+import me.neznamy.tab.shared.TAB;
+import me.neznamy.tab.shared.features.premiumvanish.PremiumVanishSupport;
+
+/**
+ * PremiumVanishSupport implementation for Velocity
+ */
+public class VelocityPremiumVanishSupport extends PremiumVanishSupport
+{
+    @Override
+    public boolean canSee(Object viewerObj, Object viewedObj)
+    {
+        if(viewerObj instanceof Player && viewedObj instanceof Player)
+        {
+            Player viewer = (Player)viewerObj;
+            Player viewed = (Player)viewedObj;
+
+            return VelocityVanishAPI.canSee(viewer, viewed);
+        }
+
+        TAB.getInstance().getErrorManager().printError("ERROR: Invalid instance!");
+        return true;
+    }
+}


### PR DESCRIPTION
I have added the support for PremiumVanish in bungeecord and velocity. Players do not need to have the "tab.seevanished" permission to see people in tablist. **Permission will still override and show everyone.**

PremiumVanish allows groups to have different "vanish levels". This modification uses its api to check if a specific player can see another one. For example you could have admins, mod and builders with different vanish levels. Admins will see everyone, mods only other mods and builder, and builders only other builders.

As premiumvanish is the leading vanish plugin for proxies, I think that this modification is very well needed.