### PR TITLE
Support to use Global Playerlist `server-groups` as Header/Footer `per-server` keys.

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/config/Configs.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/Configs.java
@@ -138,21 +138,27 @@ public class Configs {
     }
 
     public String getServerGroup(@NotNull List<Object> serverGroups, @Nullable String server) {
-        if (serverGroups.isEmpty() || server == null) return server;
+        String globalGroup = tryServerGroup(serverGroups, server);
+        if (globalGroup != null) return globalGroup;
+
+        // Use existing logic to check config key for server group (separated by ';')
+        return getGroup(serverGroups, server);
+    }
+
+    private @Nullable String tryServerGroup(@NotNull List<Object> serverGroups, @Nullable String server) {
+        if (serverGroups.isEmpty() || server == null) return null;
 
         // Check global-playerlist server-groups for this server
         FeatureManager featureManager = TAB.getInstance().getFeatureManager();
-        if (!featureManager.isFeatureEnabled(TabConstants.Feature.GLOBAL_PLAYER_LIST)) return server;
+        if (!featureManager.isFeatureEnabled(TabConstants.Feature.GLOBAL_PLAYER_LIST)) return null;
 
         GlobalPlayerList t = featureManager.getFeature(TabConstants.Feature.GLOBAL_PLAYER_LIST);
-        if (t == null) return server;
+        if (t == null) return null;
 
         String globalGroup = t.getServerGroup(server);
         for (Object serverGroup : serverGroups) {
             if (globalGroup.equals(serverGroup.toString())) return globalGroup;
         }
-
-        // Use existing logic to check config key for server group (separated by ';')
-        return getGroup(serverGroups, server);
+        return null;
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/config/Configs.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/Configs.java
@@ -1,14 +1,17 @@
 package me.neznamy.tab.shared.config;
 
 import lombok.Getter;
+import me.neznamy.tab.shared.FeatureManager;
 import me.neznamy.tab.shared.ProtocolVersion;
 import me.neznamy.tab.shared.TAB;
+import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.config.file.ConfigurationFile;
 import me.neznamy.tab.shared.config.file.YamlConfigurationFile;
 import me.neznamy.tab.shared.config.file.YamlPropertyConfigurationFile;
 import me.neznamy.tab.shared.config.mysql.MySQL;
 import me.neznamy.tab.shared.config.mysql.MySQLGroupConfiguration;
 import me.neznamy.tab.shared.config.mysql.MySQLUserConfiguration;
+import me.neznamy.tab.shared.features.globalplayerlist.GlobalPlayerList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.error.YAMLException;
@@ -132,5 +135,24 @@ public class Configs {
             }
         }
         return element;
+    }
+
+    public String getServerGroup(@NotNull List<Object> serverGroups, @Nullable String server) {
+        if (serverGroups.isEmpty() || server == null) return server;
+
+        // Check global-playerlist server-groups for this server
+        FeatureManager featureManager = TAB.getInstance().getFeatureManager();
+        if (!featureManager.isFeatureEnabled(TabConstants.Feature.GLOBAL_PLAYER_LIST)) return server;
+
+        GlobalPlayerList t = featureManager.getFeature(TabConstants.Feature.GLOBAL_PLAYER_LIST);
+        if (t == null) return server;
+
+        String globalGroup = t.getServerGroup(server);
+        for (Object serverGroup : serverGroups) {
+            if (globalGroup.equals(serverGroup.toString())) return globalGroup;
+        }
+
+        // Use existing logic to check config key for server group (separated by ';')
+        return getGroup(serverGroups, server);
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/config/file/YamlPropertyConfigurationFile.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/file/YamlPropertyConfigurationFile.java
@@ -46,10 +46,10 @@ public class YamlPropertyConfigurationFile extends YamlConfigurationFile impleme
         if ((value = getObject(new String[] {PER_WORLD, TAB.getInstance().getConfiguration().getGroup(worldGroups, world), TabConstants.DEFAULT_GROUP, property})) != null) {
             return new String[] {toString(value), category + "=" + TabConstants.DEFAULT_GROUP + ", world=" + world};
         }
-        if ((value = getObject(new String[] {PER_SERVER, TAB.getInstance().getConfiguration().getGroup(serverGroups, server), name, property})) != null) {
+        if ((value = getObject(new String[] {PER_SERVER, TAB.getInstance().getConfiguration().getServerGroup(serverGroups, server), name, property})) != null) {
             return new String[] {toString(value), category + "=" + name + ", server=" + server};
         }
-        if ((value = getObject(new String[] {PER_SERVER, TAB.getInstance().getConfiguration().getGroup(serverGroups, server), TabConstants.DEFAULT_GROUP, property})) != null) {
+        if ((value = getObject(new String[] {PER_SERVER, TAB.getInstance().getConfiguration().getServerGroup(serverGroups, server), TabConstants.DEFAULT_GROUP, property})) != null) {
             return new String[] {toString(value), category + "=" + TabConstants.DEFAULT_GROUP + ", server=" + server};
         }
         if ((value = getObject(new String[] {name, property})) != null) {

--- a/shared/src/main/java/me/neznamy/tab/shared/features/HeaderFooter.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/HeaderFooter.java
@@ -126,10 +126,10 @@ public class HeaderFooter extends TabFeature implements HeaderFooterManager, Joi
         }
         List<String> lines = config().getStringList("header-footer.per-world." + TAB.getInstance().getConfiguration().getGroup(worldGroups, p.getWorld()) + "." + property);
         if (lines == null) {
-            lines = config().getStringList("header-footer.per-server." + TAB.getInstance().getConfiguration().getGroup(serverGroups, p.getServer()) + "." + property);
+            lines = config().getStringList("header-footer.per-server." + TAB.getInstance().getConfiguration().getServerGroup(serverGroups, p.getServer()) + "." + property);
         }
         if (lines == null) {
-             lines = config().getStringList("header-footer." + property);
+            lines = config().getStringList("header-footer." + property);
         }
         if (lines == null) lines = new ArrayList<>();
         return String.join("\n", lines);


### PR DESCRIPTION
Adds support for using Global Playerlist `server-groups` config keys in the Header/Footer `per-server` section.
This allows for configuration of a server group with several velocity/bungee servers which can have a matching config key in the per-server header/footer section.

Example:

```yml
header-footer:
  per-server:
    hubs:
      header: [] #Tab Details Here
      footer: [] #Tab Details Here

global-playerlist:
  server-groups:
    hubs:
    - hub1 # Bungee/Velocity server name
    - hub2 # Bungee/Velocity server name
```

This makes config a little easier and more intuitive because adding another server with a custom TAB is as simple as adding to the global playerlist `server-groups` group, which is then used by header/footer per-server.