### PR TITLE
cleaned up the code, added a new method to api

### DIFF
--- a/api/src/main/java/me/neznamy/tab/api/TabAPI.java
+++ b/api/src/main/java/me/neznamy/tab/api/TabAPI.java
@@ -76,7 +76,7 @@ public abstract class TabAPI {
      * @return  collection of online players
      */
 
-    public @NotNull Collection<TabPlayer> getOnlineTabPlayers() {
+    public @NotNull Collection<? extends TabPlayer> getOnlineTabPlayers() {
         return Collections.unmodifiableList(
                 Arrays.asList(getOnlinePlayers()));
     }

--- a/api/src/main/java/me/neznamy/tab/api/TabAPI.java
+++ b/api/src/main/java/me/neznamy/tab/api/TabAPI.java
@@ -1,6 +1,6 @@
 package me.neznamy.tab.api;
 
-import java.util.UUID;
+import java.util.*;
 
 import lombok.NonNull;
 import lombok.Setter;
@@ -63,11 +63,23 @@ public abstract class TabAPI {
     public abstract @Nullable TabPlayer getPlayer(@NonNull String name);
 
     /**
+     * Returns array of all online players. Will return empty array if plugin is disabled (due to a broken configuration file for example).
+     *
+     * @return  array of online players
+     */
+    @Deprecated
+    public abstract @NotNull TabPlayer[] getOnlinePlayers();
+
+    /**
      * Returns collection of all online players. Will return empty list if plugin is disabled (due to a broken configuration file for example).
      *
      * @return  collection of online players
      */
-    public abstract @NotNull TabPlayer[] getOnlinePlayers();
+
+    public @NotNull Collection<TabPlayer> getOnlineTabPlayers() {
+        return Collections.unmodifiableList(
+                Arrays.asList(getOnlinePlayers()));
+    }
 
     /**
      * Return BossBar manager instance if the feature is enabled. If not, returns {@code null}.

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/features/WitherBossBar.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/features/WitherBossBar.java
@@ -51,7 +51,7 @@ public class WitherBossBar extends BossBarManagerImpl implements Listener, World
      * Updates Wither location for all online players
      */
     private void teleport() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             if (p.getVersion().getMinorVersion() > 8) continue; //sending VV packets to those
             for (BossBar line : getRegisteredBossBars().values()) {
                 if (!line.getPlayers().contains(p)) continue;

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/FoliaPlatform.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/FoliaPlatform.java
@@ -42,7 +42,7 @@ public class FoliaPlatform extends BukkitPlatform {
 
         // Folia never calls PlayerChangedWorldEvent, this is a workaround
         TAB.getInstance().getCPUManager().startRepeatingMeasuredTask(100, "Folia compatibility", "Refreshing world", () -> {
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 String bukkitWorld = ((Player)player.getPlayer()).getWorld().getName();
                 if (!player.getWorld().equals(bukkitWorld)) {
                     TAB.getInstance().getFeatureManager().onWorldChange(player.getUniqueId(), bukkitWorld);

--- a/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
@@ -59,7 +59,7 @@ public class FeatureManager {
         }
         if (TAB.getInstance().getConfiguration().getUsers() instanceof MySQLUserConfiguration) {
             MySQLUserConfiguration users = (MySQLUserConfiguration) TAB.getInstance().getConfiguration().getUsers();
-            for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) users.load(p);
+            TAB.getInstance().getOnlineTabPlayers().forEach(users::load);
         }
     }
 
@@ -76,7 +76,7 @@ public class FeatureManager {
         }
         TAB.getInstance().getPlaceholderManager().getTabExpansion().unregisterExpansion();
         if (TAB.getInstance().getPlatform() instanceof ProxyPlatform) {
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 ((ProxyTabPlayer)player).sendPluginMessage(new Unload());
             }
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/TAB.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/TAB.java
@@ -49,11 +49,6 @@ public class TAB extends TabAPI {
     /** Players by their TabList UUID for faster lookup */
     private final Map<UUID, TabPlayer> playersByTabListId = new ConcurrentHashMap<>();
 
-    /** Online player array to avoid memory allocation when iterating */
-
-    @SuppressWarnings("forRemoval")
-    private volatile TabPlayer[] onlinePlayers = new TabPlayer[0];
-
     /** Instance of plugin's main command */
     private TabCommand command;
 
@@ -182,7 +177,7 @@ public class TAB extends TabAPI {
             platform.loadPlayers();
             command = new TabCommand();
             featureManager.load();
-            for (TabPlayer p : onlinePlayers) p.markAsLoaded(false);
+            data.values().forEach(p -> p.markAsLoaded(false));
             if (eventBus != null) eventBus.fire(TabLoadEventImpl.getInstance());
             pluginDisabled = false;
             cpu.enable();
@@ -226,7 +221,6 @@ public class TAB extends TabAPI {
         pluginDisabled = true;
         data.clear();
         playersByTabListId.clear();
-        onlinePlayers = new TabPlayer[0];
         cpu.cancelAllTasks();
     }
 
@@ -239,7 +233,6 @@ public class TAB extends TabAPI {
     public void addPlayer(@NotNull TabPlayer player) {
         data.put(player.getUniqueId(), player);
         playersByTabListId.put(player.getTablistId(), player);
-        onlinePlayers = data.values().toArray(new TabPlayer[0]);
     }
 
     /**
@@ -251,7 +244,6 @@ public class TAB extends TabAPI {
     public void removePlayer(@NotNull TabPlayer player) {
         data.remove(player.getUniqueId());
         playersByTabListId.remove(player.getTablistId());
-        onlinePlayers = data.values().toArray(new TabPlayer[0]);
     }
 
     /**
@@ -289,7 +281,13 @@ public class TAB extends TabAPI {
     }
 
     @Override
-    public @NotNull Collection<me.neznamy.tab.api.TabPlayer> getOnlineTabPlayers() {
+    @Deprecated
+    public @NotNull TabPlayer[] getOnlinePlayers() {
+        return data.values().toArray(new TabPlayer[0]);
+    }
+
+    @Override
+    public @NotNull Collection<TabPlayer> getOnlineTabPlayers() {
         return Collections.unmodifiableCollection(data.values());
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/TAB.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/TAB.java
@@ -27,6 +27,8 @@ import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.error.YAMLException;
 
 import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,6 +50,8 @@ public class TAB extends TabAPI {
     private final Map<UUID, TabPlayer> playersByTabListId = new ConcurrentHashMap<>();
 
     /** Online player array to avoid memory allocation when iterating */
+
+    @SuppressWarnings("forRemoval")
     private volatile TabPlayer[] onlinePlayers = new TabPlayer[0];
 
     /** Instance of plugin's main command */
@@ -282,6 +286,11 @@ public class TAB extends TabAPI {
     public @Nullable NameTag getNameTagManager() {
         if (featureManager.isFeatureEnabled(TabConstants.Feature.NAME_TAGS)) return featureManager.getFeature(TabConstants.Feature.NAME_TAGS);
         return featureManager.getFeature(TabConstants.Feature.UNLIMITED_NAME_TAGS);
+    }
+
+    @Override
+    public @NotNull Collection<me.neznamy.tab.api.TabPlayer> getOnlineTabPlayers() {
+        return Collections.unmodifiableCollection(data.values());
     }
 
     @Override

--- a/shared/src/main/java/me/neznamy/tab/shared/backend/features/unlimitedtags/BackendNameTagX.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/backend/features/unlimitedtags/BackendNameTagX.java
@@ -38,7 +38,7 @@ public abstract class BackendNameTagX extends NameTagX implements GameModeListen
     private void startVisibilityRefreshTask() {
         TAB.getInstance().getCPUManager().startRepeatingMeasuredTask(500, featureName, TabConstants.CpuUsageCategory.REFRESHING_NAME_TAG_VISIBILITY, () -> {
 
-            for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
                 if (isPlayerDisabled(p)) continue;
                 getArmorStandManager(p).updateVisibility(false);
             }
@@ -53,9 +53,9 @@ public abstract class BackendNameTagX extends NameTagX implements GameModeListen
     @Override
     public void load() {
         super.load();
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (isPlayerDisabled(all)) continue;
-            for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                 spawnArmorStands(viewer, all);
             }
         }
@@ -72,7 +72,7 @@ public abstract class BackendNameTagX extends NameTagX implements GameModeListen
     public void onJoin(@NotNull TabPlayer connectedPlayer) {
         super.onJoin(connectedPlayer);
         if (isPlayerDisabled(connectedPlayer)) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             spawnArmorStands(viewer, connectedPlayer);
             spawnArmorStands(connectedPlayer, viewer);
         }
@@ -104,7 +104,7 @@ public abstract class BackendNameTagX extends NameTagX implements GameModeListen
     @Override
     public void onQuit(@NotNull TabPlayer disconnectedPlayer) {
         super.onQuit(disconnectedPlayer);
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             getArmorStandManager(all).unregisterPlayer((BackendTabPlayer) disconnectedPlayer);
         }
         armorStandManagerMap.get(disconnectedPlayer).destroy();
@@ -114,7 +114,7 @@ public abstract class BackendNameTagX extends NameTagX implements GameModeListen
     @Override
     public void resumeArmorStands(@NotNull TabPlayer player) {
         if (isPlayerDisabled(player)) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             spawnArmorStands(viewer, player);
         }
     }
@@ -135,7 +135,7 @@ public abstract class BackendNameTagX extends NameTagX implements GameModeListen
 
     @Override
     public void updateNameTagVisibilityView(@NotNull TabPlayer player) {
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             getArmorStandManager(all).updateVisibility(true);
         }
     }
@@ -147,7 +147,7 @@ public abstract class BackendNameTagX extends NameTagX implements GameModeListen
             getArmorStandManager(p).spawn((BackendTabPlayer) p);
         }
         //for some reason this is needed for some users
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer.getWorld().equals(from)) {
                 getArmorStandManager(p).destroy((BackendTabPlayer) viewer);
             }
@@ -156,7 +156,7 @@ public abstract class BackendNameTagX extends NameTagX implements GameModeListen
 
     @Override
     public void onGameModeChange(@NotNull TabPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             getArmorStandManager(player).updateMetadata((BackendTabPlayer) viewer);
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/backend/features/unlimitedtags/PacketListener.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/backend/features/unlimitedtags/PacketListener.java
@@ -36,7 +36,7 @@ public class PacketListener extends TabFeature implements JoinListener, QuitList
 
     @Override
     public void load() {
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             entityIdMap.put(nameTagX.getEntityId(all), all);
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/backend/features/unlimitedtags/VehicleRefresher.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/backend/features/unlimitedtags/VehicleRefresher.java
@@ -47,7 +47,7 @@ public class VehicleRefresher extends TabFeature implements JoinListener, QuitLi
                     for (TabPlayer inVehicle : playersInVehicle.keySet()) {
                         feature.getArmorStandManager(inVehicle).teleport();
                     }
-                    for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+                    for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
                         if (feature.isPreviewingNameTag(p)) {
                             feature.getArmorStandManager(p).teleport((BackendTabPlayer) p);
                         }
@@ -59,7 +59,7 @@ public class VehicleRefresher extends TabFeature implements JoinListener, QuitLi
             //There's a bug in Bukkit 1.19.3 throwing NPE on .toString(), use default toString implementation
             return v == null ? "" : v.getClass().getName() + "@" + Integer.toHexString(v.hashCode());
         });
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             Object vehicle = feature.getVehicle(p);
             if (vehicle != null) {
                 updateVehicle(vehicle);

--- a/shared/src/main/java/me/neznamy/tab/shared/command/GroupCommand.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/command/GroupCommand.java
@@ -46,7 +46,7 @@ public class GroupCommand extends PropertyCommand {
     private void remove(@Nullable TabPlayer sender, @NotNull String group) {
         if (hasPermission(sender, TabConstants.Permission.COMMAND_DATA_REMOVE)) {
             TAB.getInstance().getConfiguration().getGroups().remove(group);
-            for (TabPlayer pl : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer pl : TAB.getInstance().getOnlineTabPlayers()) {
                 if (pl.getGroup().equals(group) || TabConstants.DEFAULT_GROUP.equals(group)) {
                     pl.forceRefresh();
                 }
@@ -88,7 +88,7 @@ public class GroupCommand extends PropertyCommand {
         String[] property = TAB.getInstance().getConfiguration().getGroups().getProperty(group, type, server, world);
         if (property.length > 0 && String.valueOf(value.isEmpty() ? null : value).equals(String.valueOf(property[0]))) return;
         TAB.getInstance().getConfiguration().getGroups().setProperty(group, type, server, world, value.isEmpty() ? null : value);
-        for (TabPlayer pl : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer pl : TAB.getInstance().getOnlineTabPlayers()) {
             if (pl.getGroup().equals(group) || TabConstants.DEFAULT_GROUP.equals(group)) {
                 pl.forceRefresh();
             }

--- a/shared/src/main/java/me/neznamy/tab/shared/command/SubCommand.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/command/SubCommand.java
@@ -127,7 +127,7 @@ public abstract class SubCommand {
      */
     public @NotNull List<String> getOnlinePlayers(@NotNull String nameStart) {
         List<String> suggestions = new ArrayList<>();
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (all.getName().toLowerCase().startsWith(nameStart.toLowerCase())) suggestions.add(all.getName());
         }
         return suggestions;

--- a/shared/src/main/java/me/neznamy/tab/shared/features/BelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/BelowName.java
@@ -56,7 +56,7 @@ public class BelowName extends TabFeature implements JoinListener, Loadable, UnL
     public void load() {
         redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
         Map<TabPlayer, Integer> values = new HashMap<>();
-        for (TabPlayer loaded : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer loaded : TAB.getInstance().getOnlineTabPlayers()) {
             loaded.setProperty(this, NUMBER_PROPERTY, rawNumber);
             loaded.setProperty(this, FANCY_FORMAT_PROPERTY, fancyDisplayPlayers);
             loaded.setProperty(textRefresher, TEXT_PROPERTY, rawText);
@@ -68,7 +68,7 @@ public class BelowName extends TabFeature implements JoinListener, Loadable, UnL
             }
             values.put(loaded, getValue(loaded));
         }
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             for (Map.Entry<TabPlayer, Integer> entry : values.entrySet()) {
                 setScore(viewer, entry.getKey(), entry.getValue(), entry.getKey().getProperty(FANCY_FORMAT_PROPERTY).getFormat(viewer));
             }
@@ -77,7 +77,7 @@ public class BelowName extends TabFeature implements JoinListener, Loadable, UnL
 
     @Override
     public void unload() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             if (disableChecker.isDisabledPlayer(p)) continue;
             p.getScoreboard().unregisterObjective(OBJECTIVE_NAME);
         }
@@ -96,7 +96,7 @@ public class BelowName extends TabFeature implements JoinListener, Loadable, UnL
         }
         int number = getValue(connectedPlayer);
         Property fancy = connectedPlayer.getProperty(FANCY_FORMAT_PROPERTY);
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             setScore(all, connectedPlayer, number, fancy.getFormat(all));
             setScore(connectedPlayer, all, getValue(all), all.getProperty(FANCY_FORMAT_PROPERTY).getFormat(connectedPlayer));
         }
@@ -135,7 +135,8 @@ public class BelowName extends TabFeature implements JoinListener, Loadable, UnL
         int number = getValue(refreshed);
         Property fancy = refreshed.getProperty(FANCY_FORMAT_PROPERTY);
         fancy.update();
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             setScore(viewer, refreshed, number, fancy.getFormat(viewer));
         }
         if (redis != null) redis.updateBelowName(refreshed, number, fancy.get());
@@ -145,7 +146,7 @@ public class BelowName extends TabFeature implements JoinListener, Loadable, UnL
     public void onLoginPacket(@NotNull TabPlayer player) {
         if (disableChecker.isDisabledPlayer(player) || !player.isLoaded()) return;
         register(player);
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (all.isLoaded()) setScore(player, all, getValue(all), all.getProperty(FANCY_FORMAT_PROPERTY).getFormat(player));
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/HeaderFooter.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/HeaderFooter.java
@@ -38,14 +38,14 @@ public class HeaderFooter extends TabFeature implements HeaderFooterManager, Joi
 
     @Override
     public void load() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             onJoin(p);
         }
     }
 
     @Override
     public void unload() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             if (disableChecker.isDisabledPlayer(p)) continue;
             sendHeaderFooter(p, "","");
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/NickCompatibility.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/NickCompatibility.java
@@ -65,7 +65,7 @@ public class NickCompatibility extends TabFeature implements EntryAddListener {
     private void processNameChange(TabPlayer player) {
         TAB.getInstance().getCPUManager().runMeasuredTask(featureName, TabConstants.CpuUsageCategory.NICK_PLUGIN_COMPATIBILITY, () -> {
             if (nameTags != null && !nameTags.hasTeamHandlingPaused(player))
-                for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                     String prefix = player.getProperty(TabConstants.Property.TAGPREFIX).getFormat(viewer);
                     viewer.getScoreboard().unregisterTeam(nameTags.getSorting().getShortTeamName(player));
                     viewer.getScoreboard().registerTeam(
@@ -81,13 +81,13 @@ public class NickCompatibility extends TabFeature implements EntryAddListener {
                 }
             if (belowname != null) {
                 int value = belowname.getValue(player);
-                for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                     belowname.setScore(viewer, player, value, player.getProperty(belowname.getFANCY_FORMAT_PROPERTY()).get());
                 }
             }
             if (yellownumber != null) {
                 int value = yellownumber.getValueNumber(player);
-                for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers())
+                for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers())
                     yellownumber.setScore(viewer, player, value, player.getProperty(yellownumber.getPROPERTY_VALUE_FANCY()).get());
             }
         });
@@ -97,7 +97,7 @@ public class NickCompatibility extends TabFeature implements EntryAddListener {
         TAB.getInstance().getCPUManager().runMeasuredTask(featureName, TabConstants.CpuUsageCategory.NICK_PLUGIN_COMPATIBILITY, () -> {
             if (redisTeams != null) {
                 String teamName = redisTeams.getTeamNames().get(player);
-                for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                     viewer.getScoreboard().unregisterTeam(teamName);
                     viewer.getScoreboard().registerTeam(
                             teamName,
@@ -112,7 +112,7 @@ public class NickCompatibility extends TabFeature implements EntryAddListener {
                 }
             }
             if (redisBelowName != null) {
-                for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                     all.getScoreboard().setScore(
                             BelowName.OBJECTIVE_NAME,
                             player.getNickname(),
@@ -123,7 +123,7 @@ public class NickCompatibility extends TabFeature implements EntryAddListener {
                 }
             }
             if (redisYellowNumber != null) {
-                for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                     all.getScoreboard().setScore(
                             YellowNumber.OBJECTIVE_NAME,
                             player.getNickname(),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/PingSpoof.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/PingSpoof.java
@@ -55,15 +55,15 @@ public class PingSpoof extends TabFeature implements JoinListener, LatencyListen
 
     @Override
     public void onJoin(@NotNull TabPlayer connectedPlayer) {
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             connectedPlayer.getTabList().updateLatency(all.getTablistId(), value);
             all.getTabList().updateLatency(connectedPlayer.getTablistId(), value);
         }
     }
 
     private void updateAll(boolean realPing) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            for (TabPlayer target : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
+            for (TabPlayer target : TAB.getInstance().getOnlineTabPlayers()) {
                 viewer.getTabList().updateLatency(target.getTablistId(), realPing ? target.getPing() : value);
             }
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/PlaceholderManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/PlaceholderManagerImpl.java
@@ -83,7 +83,8 @@ public class PlaceholderManagerImpl extends TabFeature implements PlaceholderMan
 
     private void processRefreshResults(@NotNull PlaceholderRefreshTask task) {
         long time = System.nanoTime();
-        Map<TabPlayer, Set<Refreshable>> update = new HashMap<>(TAB.getInstance().getOnlinePlayers().length + 1, 1);
+        Map<TabPlayer, Set<Refreshable>> update = new HashMap<>(
+                TAB.getInstance().getOnlineTabPlayers().size() + 1, 1);
         updateServerPlaceholders(task.getServerPlaceholderResults(), update);
         updatePlayerPlaceholders(task.getPlayerPlaceholderResults(), update);
         Map<TabPlayer, Set<Refreshable>> forceUpdate = updateRelationalPlaceholders(task.getRelationalPlaceholderResults());
@@ -112,7 +113,8 @@ public class PlaceholderManagerImpl extends TabFeature implements PlaceholderMan
     @NotNull
     private Map<TabPlayer, Set<Refreshable>> updateRelationalPlaceholders(
             @NotNull Map<RelationalPlaceholderImpl, Map<TabPlayer, Map<TabPlayer, Object>>> results) {
-        Map<TabPlayer, Set<Refreshable>> update = new HashMap<>(TAB.getInstance().getOnlinePlayers().length + 1, 1);
+        Map<TabPlayer, Set<Refreshable>> update = new HashMap<>(
+                TAB.getInstance().getOnlineTabPlayers().size() + 1, 1);
         for (Entry<RelationalPlaceholderImpl, Map<TabPlayer, Map<TabPlayer, Object>>> entry : results.entrySet()) {
             RelationalPlaceholderImpl placeholder = entry.getKey();
             for (Entry<TabPlayer, Map<TabPlayer, Object>> viewerResult : entry.getValue().entrySet()) {
@@ -151,7 +153,7 @@ public class PlaceholderManagerImpl extends TabFeature implements PlaceholderMan
         for (Entry<ServerPlaceholderImpl, Object> entry : results.entrySet()) {
             ServerPlaceholderImpl placeholder = entry.getKey();
             if (placeholder.hasValueChanged(entry.getValue())) {
-                for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                     placeholder.updateParents(all);
                     update.computeIfAbsent(all, k -> new HashSet<>()).addAll(getPlaceholderUsage(placeholder.getIdentifier()));
                 }
@@ -195,7 +197,7 @@ public class PlaceholderManagerImpl extends TabFeature implements PlaceholderMan
         registeredPlaceholders.put(placeholder.getIdentifier(), placeholder);
         recalculateUsedPlaceholders();
         if (override && placeholderUsage.containsKey(placeholder.getIdentifier())) {
-            for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!p.isLoaded()) continue;
                 placeholderUsage.get(placeholder.getIdentifier()).forEach(f -> f.refresh(p, true));
             }
@@ -212,9 +214,7 @@ public class PlaceholderManagerImpl extends TabFeature implements PlaceholderMan
                 ((ServerPlaceholderImpl)pl).update();
             }
         }
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
-            onJoin(p);
-        }
+        TAB.getInstance().getOnlineTabPlayers().forEach(this::onJoin);
     }
 
     /**
@@ -256,7 +256,7 @@ public class PlaceholderManagerImpl extends TabFeature implements PlaceholderMan
         if (placeholderUsage.computeIfAbsent(identifier, x -> new HashSet<>()).add(feature)) {
             recalculateUsedPlaceholders();
             TabPlaceholder p = getPlaceholder(identifier);
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 tabExpansion.setPlaceholderValue(all, p.getIdentifier(), p.getLastValue(all));
             }
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/PlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/PlayerList.java
@@ -53,7 +53,7 @@ public class PlayerList extends TabFeature implements TabListFormatManager, Join
         TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.PLAYER_LIST + "-Condition", disableChecker);
         if (antiOverrideTabList) {
             TAB.getInstance().getCPUManager().startRepeatingMeasuredTask(500, featureName, TabConstants.CpuUsageCategory.ANTI_OVERRIDE, () -> {
-                for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
                     p.getTabList().checkDisplayNames();
                 }
             });
@@ -112,7 +112,7 @@ public class PlayerList extends TabFeature implements TabListFormatManager, Join
      */
     protected void updatePlayer(@NotNull me.neznamy.tab.api.TabPlayer p, boolean format) {
         TabPlayer player = (TabPlayer) p;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer.getVersion().getMinorVersion() < 8) continue;
             UUID tablistId = getTablistUUID(player, viewer);
             viewer.getTabList().updateDisplayName(tablistId, format ? getTabFormat(player, viewer) :
@@ -144,7 +144,7 @@ public class PlayerList extends TabFeature implements TabListFormatManager, Join
     @Override
     public void load() {
         redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             updateProperties(all);
             if (disableChecker.isDisableConditionMet(all)) {
                 disableChecker.addDisabledPlayer(all);
@@ -152,9 +152,9 @@ public class PlayerList extends TabFeature implements TabListFormatManager, Join
                 if (redis != null) redis.updateTabFormat(all, all.getProperty(TabConstants.Property.TABPREFIX).get() + all.getProperty(TabConstants.Property.CUSTOMTABNAME).get() + all.getProperty(TabConstants.Property.TABSUFFIX).get());
             }
         }
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer.getVersion().getMinorVersion() < 8) continue;
-            for (TabPlayer target : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer target : TAB.getInstance().getOnlineTabPlayers()) {
                 if (disableChecker.isDisabledPlayer(target)) continue;
                 viewer.getTabList().updateDisplayName(getTablistUUID(target, viewer), getTabFormat(target, viewer));
             }
@@ -164,9 +164,9 @@ public class PlayerList extends TabFeature implements TabListFormatManager, Join
     @Override
     public void unload() {
         disabling = true;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer.getVersion().getMinorVersion() < 8) continue;
-            for (TabPlayer target : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer target : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!disableChecker.isDisabledPlayer(target)) viewer.getTabList().updateDisplayName(getTablistUUID(target, target), null);
             }
         }
@@ -177,7 +177,7 @@ public class PlayerList extends TabFeature implements TabListFormatManager, Join
         if (updateProperties(p) && !disableChecker.isDisabledPlayer(p)) updatePlayer(p, true);
         if (TAB.getInstance().getFeatureManager().isFeatureEnabled(TabConstants.Feature.PIPELINE_INJECTION)) return;
         TAB.getInstance().getCPUManager().runTaskLater(300, featureName, TabConstants.CpuUsageCategory.PLAYER_JOIN, () -> {
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!disableChecker.isDisabledPlayer(all) && p.getVersion().getMinorVersion() >= 8)
                     p.getTabList().updateDisplayName(getTablistUUID(all, p), getTabFormat(all, p));
                 if (all != p && !disableChecker.isDisabledPlayer(p) && all.getVersion().getMinorVersion() >= 8)
@@ -232,7 +232,7 @@ public class PlayerList extends TabFeature implements TabListFormatManager, Join
         Runnable r = () -> {
             refresh(connectedPlayer, true);
             if (connectedPlayer.getVersion().getMinorVersion() < 8) return;
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 if (all == connectedPlayer) continue; //already sent 4 lines above
                 connectedPlayer.getTabList().updateDisplayName(getTablistUUID(all, connectedPlayer), getTabFormat(all, connectedPlayer));
             }
@@ -259,7 +259,7 @@ public class PlayerList extends TabFeature implements TabListFormatManager, Join
     @Override
     public void onVanishStatusChange(@NotNull TabPlayer player) {
         if (player.isVanished() || disableChecker.isDisabledPlayer(player)) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer.getVersion().getMinorVersion() < 8) continue;
             viewer.getTabList().updateDisplayName(player.getTablistId(), getTabFormat(player, viewer));
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/SpectatorFix.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/SpectatorFix.java
@@ -30,7 +30,7 @@ public class SpectatorFix extends TabFeature implements JoinListener, GameModeLi
      *          If target's view should be updated as well
      */
     private void updatePlayer(@NotNull TabPlayer viewer, boolean realGameMode, boolean mutually) {
-        for (TabPlayer target : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer target : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer == target) continue;
             if (target.getGamemode() == 3 && !viewer.hasPermission(TabConstants.Permission.SPECTATOR_BYPASS)) {
                 viewer.getTabList().updateGameMode(target.getTablistId(), realGameMode ? target.getGamemode() : 0);
@@ -44,7 +44,7 @@ public class SpectatorFix extends TabFeature implements JoinListener, GameModeLi
     @Override
     public void onGameModeChange(@NotNull TabPlayer player) {
         if (player.getGamemode() != 3) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer.hasPermission(TabConstants.Permission.SPECTATOR_BYPASS)) continue;
             if (player != viewer && player.getServer().equals(viewer.getServer())) {
                 viewer.getTabList().updateGameMode(player.getTablistId(), 0);
@@ -60,14 +60,14 @@ public class SpectatorFix extends TabFeature implements JoinListener, GameModeLi
 
     @Override
     public void load() {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             updatePlayer(viewer, false, false);
         }
     }
 
     @Override
     public void unload() {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             updatePlayer(viewer, true, false);
         }
     }
@@ -76,7 +76,7 @@ public class SpectatorFix extends TabFeature implements JoinListener, GameModeLi
     public void onServerChange(@NotNull TabPlayer changed, @NotNull String from, @NotNull String to) {
         // 200ms delay for global playerlist, taking extra time
         TAB.getInstance().getCPUManager().runTaskLater(300, featureName, TabConstants.CpuUsageCategory.SERVER_SWITCH, () -> {
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 updatePlayer(all, false, true);
             }
         });
@@ -86,7 +86,7 @@ public class SpectatorFix extends TabFeature implements JoinListener, GameModeLi
     public void onWorldChange(@NotNull TabPlayer changed, @NotNull String from, @NotNull String to) {
         // Some server versions may resend gamemode on world switch, resend false value again
         if (changed.getGamemode() != 3) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer == changed || viewer.hasPermission(TabConstants.Permission.SPECTATOR_BYPASS)) continue;
             viewer.getTabList().updateGameMode(changed.getTablistId(), 0);
         }
@@ -95,7 +95,7 @@ public class SpectatorFix extends TabFeature implements JoinListener, GameModeLi
     @Override
     public void onVanishStatusChange(@NotNull TabPlayer player) {
         if (player.isVanished() || player.getGamemode() != 3) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer == player || viewer.hasPermission(TabConstants.Permission.SPECTATOR_BYPASS)) continue;
             viewer.getTabList().updateGameMode(player.getTablistId(), 0);
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/YellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/YellowNumber.java
@@ -68,7 +68,7 @@ public class YellowNumber extends TabFeature implements JoinListener, Loadable, 
     public void load() {
         redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
         Map<TabPlayer, Integer> values = new HashMap<>();
-        for (TabPlayer loaded : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer loaded : TAB.getInstance().getOnlineTabPlayers()) {
             loaded.setProperty(this, PROPERTY_VALUE, rawValue);
             loaded.setProperty(this, PROPERTY_VALUE_FANCY, rawValueFancy);
             if (disableChecker.isDisableConditionMet(loaded)) {
@@ -78,7 +78,7 @@ public class YellowNumber extends TabFeature implements JoinListener, Loadable, 
             }
             values.put(loaded, getValueNumber(loaded));
         }
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             for (Map.Entry<TabPlayer, Integer> entry : values.entrySet()) {
                 setScore(viewer, entry.getKey(), entry.getValue(), entry.getKey().getProperty(PROPERTY_VALUE_FANCY).getFormat(viewer));
             }
@@ -87,7 +87,7 @@ public class YellowNumber extends TabFeature implements JoinListener, Loadable, 
 
     @Override
     public void unload() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             if (disableChecker.isDisabledPlayer(p) || p.isBedrockPlayer()) continue;
             p.getScoreboard().unregisterObjective(OBJECTIVE_NAME);
         }
@@ -105,7 +105,7 @@ public class YellowNumber extends TabFeature implements JoinListener, Loadable, 
         int value = getValueNumber(connectedPlayer);
         Property valueFancy = connectedPlayer.getProperty(PROPERTY_VALUE_FANCY);
         valueFancy.update();
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             setScore(all, connectedPlayer, value, valueFancy.getFormat(connectedPlayer));
             setScore(connectedPlayer, all, getValueNumber(all), all.getProperty(PROPERTY_VALUE_FANCY).getFormat(connectedPlayer));
         }
@@ -133,7 +133,7 @@ public class YellowNumber extends TabFeature implements JoinListener, Loadable, 
         int value = getValueNumber(refreshed);
         Property fancy = refreshed.getProperty(PROPERTY_VALUE_FANCY);
         fancy.update();
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             setScore(viewer, refreshed, value, fancy.getFormat(viewer));
         }
         if (redis != null) redis.updateYellowNumber(refreshed, value, fancy.get());
@@ -143,7 +143,7 @@ public class YellowNumber extends TabFeature implements JoinListener, Loadable, 
     public void onLoginPacket(@NotNull TabPlayer p) {
         if (disableChecker.isDisabledPlayer(p) || !p.isLoaded()) return;
         register(p);
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (all.isLoaded()) setScore(p, all, getValueNumber(all), all.getProperty(PROPERTY_VALUE_FANCY).getFormat(p));
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/bossbar/BossBarManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/bossbar/BossBarManagerImpl.java
@@ -88,7 +88,7 @@ public class BossBarManagerImpl extends TabFeature implements BossBarManager, Jo
     @Override
     public void load() {
         TAB.getInstance().getPlaceholderManager().registerServerPlaceholder(TabConstants.Placeholder.COUNTDOWN, 100, () -> (announceEndTime - System.currentTimeMillis()) / 1000);
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             onJoin(p);
         }
     }
@@ -112,7 +112,7 @@ public class BossBarManagerImpl extends TabFeature implements BossBarManager, Jo
 
     @Override
     public void unload() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             for (BossBar line : lineValues) {
                 line.removePlayer(p);
             }
@@ -253,8 +253,12 @@ public class BossBarManagerImpl extends TabFeature implements BossBarManager, Jo
     public void announceBossBar(@NonNull String bossBar, int duration) {
         BossBar line = registeredBossBars.get(bossBar);
         if (line == null) throw new IllegalArgumentException("No registered BossBar found with name " + bossBar);
-        List<TabPlayer> players = Arrays.stream(TAB.getInstance().getOnlinePlayers()).filter(
-                this::hasBossBarVisible).collect(Collectors.toList());
+        List<TabPlayer> players = TAB.getInstance()
+                .getOnlineTabPlayers()
+                .stream()
+                .filter(this::hasBossBarVisible)
+                .collect(Collectors.toList());
+
         TAB.getInstance().getCPUManager().runMeasuredTask(featureName, "Adding announced BossBar", () -> {
             announcedBossBars.add(line);
             announceEndTime = System.currentTimeMillis() + duration* 1000L;
@@ -264,9 +268,7 @@ public class BossBarManagerImpl extends TabFeature implements BossBarManager, Jo
         });
         TAB.getInstance().getCPUManager().runTaskLater(duration*1000,
                 featureName, "Removing announced BossBar", () -> {
-            for (TabPlayer all : players) {
-                line.removePlayer(all);
-            }
+            players.forEach(line::removePlayer);
             announcedBossBars.remove(line);
         });
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
@@ -32,7 +32,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
         for (Map.Entry<String, List<String>> entry : sharedServers.entrySet()) {
             TAB.getInstance().getPlaceholderManager().registerServerPlaceholder(TabConstants.Placeholder.globalPlayerListGroup(entry.getKey()), 1000, () -> {
                 int count = 0;
-                for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                     if (entry.getValue().contains(player.getServer()) && !player.isVanished()) count++;
                 }
                 return count;
@@ -43,9 +43,9 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
     @Override
     public void load() {
         TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.GLOBAL_PLAYER_LIST_LATENCY, new LatencyRefresher());
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             List<TabList.Entry> entries = new ArrayList<>();
-            for (TabPlayer displayed : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer displayed : TAB.getInstance().getOnlineTabPlayers()) {
                 if (viewer.getServer().equals(displayed.getServer())) continue;
                 if (shouldSee(viewer, displayed)) entries.add(getAddInfoData(displayed, viewer));
             }
@@ -77,8 +77,8 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
 
     @Override
     public void unload() {
-        for (TabPlayer displayed : TAB.getInstance().getOnlinePlayers()) {
-            for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer displayed : TAB.getInstance().getOnlineTabPlayers()) {
+            for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!displayed.getServer().equals(viewer.getServer())) viewer.getTabList().removeEntry(displayed.getTablistId());
             }
         }
@@ -86,7 +86,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
 
     @Override
     public void onJoin(@NotNull TabPlayer connectedPlayer) {
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (connectedPlayer.getServer().equals(all.getServer())) continue;
             if (shouldSee(all, connectedPlayer)) {
                 all.getTabList().addEntry(getAddInfoData(connectedPlayer, all));
@@ -99,7 +99,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
 
     @Override
     public void onQuit(@NotNull TabPlayer disconnectedPlayer) {
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (all == disconnectedPlayer) continue;
             all.getTabList().removeEntry(disconnectedPlayer.getTablistId());
         }
@@ -109,7 +109,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
     public void onServerChange(@NotNull TabPlayer changed, @NotNull String from, @NotNull String to) {
         // Player who switched server is removed from tablist of other players in ~70-110ms (depending on online count), re-add with a delay
         TAB.getInstance().getCPUManager().runTaskLater(200, featureName, TabConstants.CpuUsageCategory.SERVER_SWITCH, () -> {
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 // Remove for everyone and add back if visible, easy solution to display-others-as-spectators option
                 // Also do not remove/add players from the same server, let backend handle it
                 if (!all.getServer().equals(changed.getServer())) {
@@ -124,7 +124,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
 
     @Override
     public void onTabListClear(@NotNull TabPlayer player) {
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             // Ignore players on the same server, since the server already sends add packet
             if (!all.getServer().equals(player.getServer()) && shouldSee(player, all)) {
                 player.getTabList().addEntry(getAddInfoData(all, player));
@@ -151,7 +151,7 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
 
     @Override
     public void onGameModeChange(@NotNull TabPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (!player.getServer().equals(viewer.getServer())) {
                 viewer.getTabList().updateGameMode(player.getTablistId(), othersAsSpectators ? 3 : player.getGamemode());
             }
@@ -161,14 +161,14 @@ public class GlobalPlayerList extends TabFeature implements JoinListener, QuitLi
     @Override
     public void onVanishStatusChange(@NotNull TabPlayer p) {
         if (p.isVanished()) {
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 if (all == p) continue;
                 if (!shouldSee(all, p)) {
                     all.getTabList().removeEntry(p.getTablistId());
                 }
             }
         } else {
-            for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                 if (viewer == p) continue;
                 if (shouldSee(viewer, p)) {
                     viewer.getTabList().addEntry(getAddInfoData(p, viewer));

--- a/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/LatencyRefresher.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/LatencyRefresher.java
@@ -21,7 +21,7 @@ public class LatencyRefresher extends TabFeature implements Refreshable {
     @Override
     public void refresh(@NotNull TabPlayer p, boolean force) {
         //player ping changed, must manually update latency for players on other servers
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (!p.getServer().equals(all.getServer())) all.getTabList().updateLatency(p.getTablistId(), p.getPing());
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/injection/PipelineInjector.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/injection/PipelineInjector.java
@@ -37,14 +37,14 @@ public abstract class PipelineInjector extends TabFeature implements JoinListene
         boolean respectOtherScoreboardPlugins = config().getBoolean("scoreboard.enabled", false) &&
                 config().getBoolean("scoreboard.respect-other-plugins", true);
         byteBufDeserialization = antiOverrideTeams || respectOtherScoreboardPlugins;
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             inject(p);
         }
     }
 
     @Override
     public void unload() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             uninject(p);
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutLatencyRefresher.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutLatencyRefresher.java
@@ -21,7 +21,7 @@ public class LayoutLatencyRefresher extends TabFeature implements Refreshable {
 
     @Override
     public void refresh(@NotNull TabPlayer p, boolean force) {
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (all.getVersion().getMinorVersion() < 8) continue;
             LayoutView layout = manager.getViews().get(all);
             if (layout == null) continue;

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
@@ -81,7 +81,7 @@ public class LayoutManagerImpl extends TabFeature implements LayoutManager, Join
         playerList = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PLAYER_LIST);
         teamsEnabled = TAB.getInstance().getNameTagManager() != null;
         TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.LAYOUT_LATENCY, new LayoutLatencyRefresher(this));
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             onJoin(p);
         }
     }
@@ -119,7 +119,7 @@ public class LayoutManagerImpl extends TabFeature implements LayoutManager, Join
 
         // Unformat original entries for players who can see a layout to avoid spaces due to unparsed placeholders and such
         if (highest == null) return;
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             p.getTabList().updateDisplayName(all.getTablistId(), null);
         }
     }
@@ -151,7 +151,7 @@ public class LayoutManagerImpl extends TabFeature implements LayoutManager, Join
 
     @Override
     public void unload() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             if (p.getVersion().getMinorVersion() < 8 || p.isBedrockPlayer()) continue;
             p.getTabList().removeEntries(uuids.values());
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/CollisionManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/CollisionManager.java
@@ -41,7 +41,7 @@ public class CollisionManager extends TabFeature implements JoinListener, Loadab
             return newCollision;
         });
         addUsedPlaceholder(TabConstants.Placeholder.COLLISION);
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             collision.put(all, true);
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/unlimited/NameTagX.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/unlimited/NameTagX.java
@@ -274,8 +274,8 @@ public abstract class NameTagX extends NameTag implements UnlimitedNameTagManage
     @Override
     public void resumeTeamHandling(@NonNull me.neznamy.tab.api.TabPlayer player) {
         Preconditions.checkLoaded(player);
-        if (!teamHandlingPaused.contains(player)) return;
-        teamHandlingPaused.remove(player); //removing before, so registerTeam method runs
+        //removing before, so registerTeam method runs
+        if (!teamHandlingPaused.remove(player)) return;
         if (!getDisableChecker().isDisabledPlayer((TabPlayer) player)) registerTeam((TabPlayer) player);
         resumeArmorStands((TabPlayer) player);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/unlimited/NameTagX.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/unlimited/NameTagX.java
@@ -52,7 +52,7 @@ public abstract class NameTagX extends NameTag implements UnlimitedNameTagManage
         if (invisibleNameTags) {
             TAB.getInstance().getConfigHelper().startup().invisibleAndUnlimitedNameTagsAreMutuallyExclusive();
         }
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             updateProperties(all);
             armorStandManagerMap.put(all, armorStandFunction.apply(this, all));
             if (unlimitedDisableChecker.isDisableConditionMet(all)) {
@@ -86,7 +86,7 @@ public abstract class NameTagX extends NameTag implements UnlimitedNameTagManage
     @Override
     public void unload() {
         super.unload();
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             getArmorStandManager(p).destroy();
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/redis/RedisSupport.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/redis/RedisSupport.java
@@ -190,7 +190,7 @@ public abstract class RedisSupport extends TabFeature implements JoinListener, Q
         }
         overridePlaceholders();
         TAB.getInstance().getEventBus().register(TabPlaceholderRegisterEvent.class, eventHandler);
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) onJoin(p);
+        TAB.getInstance().getOnlineTabPlayers().forEach(this::onJoin);
         sendMessage(new LoadRequest());
     }
 
@@ -201,7 +201,7 @@ public abstract class RedisSupport extends TabFeature implements JoinListener, Q
                 String server = identifier.substring(8, identifier.length()-1);
                 event.setServerPlaceholder(() -> {
                     int count = 0;
-                    for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+                    for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                         if (player.getServer().equals(server) && !player.isVanished()) count++;
                     }
                     for (RedisPlayer player : redisPlayers.values()) {
@@ -213,7 +213,7 @@ public abstract class RedisSupport extends TabFeature implements JoinListener, Q
         };
         TAB.getInstance().getPlaceholderManager().registerServerPlaceholder(TabConstants.Placeholder.ONLINE, 1000, () -> {
             int count = 0;
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!player.isVanished()) count++;
             }
             for (RedisPlayer player : redisPlayers.values()) {
@@ -223,7 +223,7 @@ public abstract class RedisSupport extends TabFeature implements JoinListener, Q
         });
         TAB.getInstance().getPlaceholderManager().registerServerPlaceholder(TabConstants.Placeholder.STAFF_ONLINE, 1000, () -> {
             int count = 0;
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!player.isVanished() && player.hasPermission(TabConstants.Permission.STAFF)) count++;
             }
             for (RedisPlayer player : redisPlayers.values()) {
@@ -235,7 +235,7 @@ public abstract class RedisSupport extends TabFeature implements JoinListener, Q
 
     @Override
     public void unload() {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) onQuit(p);
+        TAB.getInstance().getOnlineTabPlayers().forEach(this::onQuit);
         TAB.getInstance().getEventBus().unregister(eventHandler);
         unregister();
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisBelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisBelowName.java
@@ -47,7 +47,7 @@ public class RedisBelowName extends RedisFeature {
 
     @Override
     public void onJoin(@NotNull RedisPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             viewer.getScoreboard().setScore(
                     BelowName.OBJECTIVE_NAME,
                     player.getNickname(),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisGlobalPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisGlobalPlayerList.java
@@ -34,7 +34,7 @@ public class RedisGlobalPlayerList extends RedisFeature {
 
     @Override
     public void onJoin(@NotNull RedisPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (shouldSee(viewer, player) && !viewer.getServer().equals(player.getServer())) {
                 viewer.getTabList().addEntry(getEntry(player));
             }
@@ -44,7 +44,7 @@ public class RedisGlobalPlayerList extends RedisFeature {
     @Override
     public void onServerSwitch(@NotNull RedisPlayer player) {
         TAB.getInstance().getCPUManager().runTaskLater(200, redisSupport.getFeatureName(), TabConstants.CpuUsageCategory.SERVER_SWITCH, () -> {
-            for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                 if (viewer.getServer().equals(player.getServer())) continue;
                 if (shouldSee(viewer, player)) {
                     viewer.getTabList().addEntry(getEntry(player));
@@ -57,7 +57,7 @@ public class RedisGlobalPlayerList extends RedisFeature {
 
     @Override
     public void onQuit(@NotNull RedisPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (!player.getServer().equals(viewer.getServer())) {
                 viewer.getTabList().removeEntry(player.getUniqueId());
             }
@@ -108,13 +108,13 @@ public class RedisGlobalPlayerList extends RedisFeature {
     @Override
     public void onVanishStatusChange(@NotNull RedisPlayer player) {
         if (player.isVanished()) {
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!shouldSee(all, player)) {
                     all.getTabList().removeEntry(player.getUniqueId());
                 }
             }
         } else {
-            for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                 if (shouldSee(viewer, player)) {
                     viewer.getTabList().addEntry(getEntry(player));
                 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisPlayerList.java
@@ -39,7 +39,7 @@ public class RedisPlayerList extends RedisFeature {
 
     @Override
     public void onJoin(@NotNull RedisPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer.getVersion().getMinorVersion() < 8) continue;
             viewer.getTabList().updateDisplayName(player.getUniqueId(), IChatBaseComponent.optimizedComponent(values.get(player)));
         }
@@ -69,7 +69,7 @@ public class RedisPlayerList extends RedisFeature {
     @Override
     public void onVanishStatusChange(@NotNull RedisPlayer player) {
         if (player.isVanished()) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             if (viewer.getVersion().getMinorVersion() < 8) continue;
             viewer.getTabList().updateDisplayName(player.getUniqueId(), IChatBaseComponent.optimizedComponent(getFormat(player)));
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisTeams.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisTeams.java
@@ -46,7 +46,7 @@ public class RedisTeams extends RedisFeature {
 
     @Override
     public void onJoin(@NotNull RedisPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             viewer.getScoreboard().registerTeam(teamNames.get(player), prefixes.get(player), suffixes.get(player),
                     nameVisibilities.get(player), CollisionRule.ALWAYS,
                     Collections.singletonList(player.getNickname()), 2, EnumChatFormat.lastColorsOf(prefixes.get(player)));
@@ -55,7 +55,7 @@ public class RedisTeams extends RedisFeature {
 
     @Override
     public void onQuit(@NotNull RedisPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             viewer.getScoreboard().unregisterTeam(teamNames.get(player));
         }
     }
@@ -85,7 +85,7 @@ public class RedisTeams extends RedisFeature {
 
     private @NotNull String checkTeamName(@NotNull RedisPlayer player, @NotNull String currentName15, int id) {
         String potentialTeamName = currentName15 + (char)id;
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (nameTags.getSorting().getShortTeamName(all).equals(potentialTeamName)) {
                 return checkTeamName(player, currentName15, id+1);
             }
@@ -137,13 +137,13 @@ public class RedisTeams extends RedisFeature {
             prefixes.put(target, prefix);
             suffixes.put(target, suffix);
             if (!oldTeamName.equals(newTeamName)) {
-                for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                     viewer.getScoreboard().unregisterTeam(oldTeamName);
                     viewer.getScoreboard().registerTeam(newTeamName, prefix, suffix, nameVisibility,
                             CollisionRule.ALWAYS, Collections.singletonList(target.getNickname()), 2, EnumChatFormat.lastColorsOf(prefix));
                 }
             } else {
-                for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                     viewer.getScoreboard().updateTeam(oldTeamName, prefix, suffix, nameVisibility,
                             CollisionRule.ALWAYS, 2, EnumChatFormat.lastColorsOf(prefix));
                 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisYellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/redis/feature/RedisYellowNumber.java
@@ -47,7 +47,7 @@ public class RedisYellowNumber extends RedisFeature {
 
     @Override
     public void onJoin(@NotNull RedisPlayer player) {
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
             viewer.getScoreboard().setScore(
                     YellowNumber.OBJECTIVE_NAME,
                     player.getNickname(),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/redis/message/Load.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/redis/message/Load.java
@@ -7,21 +7,23 @@ import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.platform.TabPlayer;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
+
 @NoArgsConstructor
 public class Load extends RedisMessage {
 
     private RedisSupport redisSupport;
-    private TabPlayer[] players;
+    private Collection<TabPlayer> players;
     private PlayerJoin[] decodedPlayers;
 
-    public Load(@NotNull RedisSupport redisSupport, @NotNull TabPlayer[] players) {
+    public Load(@NotNull RedisSupport redisSupport, @NotNull Collection<TabPlayer> players) {
         this.redisSupport = redisSupport;
         this.players = players;
     }
 
     @Override
     public void write(@NotNull ByteArrayDataOutput out) {
-        out.writeInt(players.length);
+        out.writeInt(players.size());
         for (TabPlayer player : players) {
             new PlayerJoin(redisSupport, player).write(out);
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/redis/message/LoadRequest.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/redis/message/LoadRequest.java
@@ -20,6 +20,6 @@ public class LoadRequest extends RedisMessage {
 
     @Override
     public void process(@NotNull RedisSupport redisSupport) {
-        redisSupport.sendMessage(new Load(redisSupport, TAB.getInstance().getOnlinePlayers()));
+        redisSupport.sendMessage(new Load(redisSupport, TAB.getInstance().getOnlineTabPlayers()));
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardImpl.java
@@ -158,11 +158,7 @@ public class ScoreboardImpl extends TabFeature implements me.neznamy.tab.api.sco
 
     @Override
     public void unregister() {
-
-        players.removeIf(all -> {
-            removePlayer(all);
-            return true;
-        });
+        new ArrayList<>(players).forEach(this::removePlayer);
     }
 
     /**
@@ -234,18 +230,18 @@ public class ScoreboardImpl extends TabFeature implements me.neznamy.tab.api.sco
      */
     public void recalculateScores(@NonNull TabPlayer p) {
         if (!manager.isUsingNumbers()) return;
-        List<Line> linesReversed = new ArrayList<>(lines);
-        Collections.reverse(linesReversed);
         int score = manager.getStaticNumber();
-        for (Line line : linesReversed) {
-            Property pr = p.getProperty(((ScoreboardLine) line).getTextProperty());
-            if (pr.getCurrentRawValue().isEmpty() || (!pr.getCurrentRawValue().isEmpty() && !pr.get().isEmpty())) {
+        for (int i = lines.size() - 1; i >= 0; --i) {
+            ScoreboardLine line = ((ScoreboardLine) lines.get(i));
+            Property pr = p.getProperty(line.getTextProperty());
+            if (pr.getCurrentRawValue().isEmpty() ||
+                    (!pr.getCurrentRawValue().isEmpty() && !pr.get().isEmpty())) {
                 p.getScoreboard().setScore(
                         ScoreboardManagerImpl.OBJECTIVE_NAME,
-                        ((ScoreboardLine)line).getPlayerName(p),
+                        line.getPlayerName(p),
                         score++,
                         null, // Makes no sense for TAB
-                        ((ScoreboardLine) line).getScoreRefresher().getNumberFormat(p)
+                        line.getScoreRefresher().getNumberFormat(p)
                 );
             }
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardImpl.java
@@ -139,8 +139,7 @@ public class ScoreboardImpl extends TabFeature implements me.neznamy.tab.api.sco
      *          Player to send this scoreboard to
      */
     public void addPlayer(@NonNull TabPlayer p) {
-        if (players.contains(p)) return; //already registered
-        players.add(p);
+        if (!players.add(p)) return; //already registered
         p.setProperty(this, titleProperty, title);
         p.getScoreboard().registerObjective(
                 ScoreboardManagerImpl.OBJECTIVE_NAME,
@@ -159,10 +158,11 @@ public class ScoreboardImpl extends TabFeature implements me.neznamy.tab.api.sco
 
     @Override
     public void unregister() {
-        for (TabPlayer all : players.toArray(new TabPlayer[0])) {
+
+        players.removeIf(all -> {
             removePlayer(all);
-        }
-        players.clear();
+            return true;
+        });
     }
 
     /**
@@ -172,13 +172,12 @@ public class ScoreboardImpl extends TabFeature implements me.neznamy.tab.api.sco
      *          Player to unregister
      */
     public void removePlayer(@NonNull TabPlayer p) {
-        if (!players.contains(p)) return; //not registered
+        if (!players.remove(p)) return; //not registered
         p.getScoreboard().unregisterObjective(ScoreboardManagerImpl.OBJECTIVE_NAME);
         for (Line line : lines) {
             if (((ScoreboardLine)line).isShownTo(p))
                 p.getScoreboard().unregisterTeam(((ScoreboardLine)line).getTeamName());
         }
-        players.remove(p);
         manager.getActiveScoreboards().remove(p);
         TAB.getInstance().getPlaceholderManager().getTabExpansion().setScoreboardName(p, "");
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardManagerImpl.java
@@ -78,7 +78,7 @@ public class ScoreboardManagerImpl extends TabFeature implements ScoreboardManag
             registeredScoreboards.put(entry.getKey(), sb);
             TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.scoreboardLine(entry.getKey()), sb);
         }
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             onJoin(p);
         }
     }
@@ -300,7 +300,7 @@ public class ScoreboardManagerImpl extends TabFeature implements ScoreboardManag
         // todo: maybe a race
         TAB.getInstance().getCPUManager().runMeasuredTask(featureName, "Adding announced Scoreboard", () -> {
             announcement = sb;
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!hasScoreboardVisible(all)) continue;
                 ScoreboardImpl p = activeScoreboards.get(all);
                 if (p != null) {
@@ -312,7 +312,7 @@ public class ScoreboardManagerImpl extends TabFeature implements ScoreboardManag
         });
         TAB.getInstance().getCPUManager().runTaskLater(duration*1000,
                 featureName, "Removing announced Scoreboard", () -> {
-            for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!hasScoreboardVisible(all)) continue;
                 sb.removePlayer(all);
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/Sorting.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/Sorting.java
@@ -77,7 +77,7 @@ public class Sorting extends TabFeature implements SortingManager, JoinListener,
         constructTeamNames(p);
         if (!shortTeamNames.get(p).equals(previousShortName)) {
             if (nameTags != null && getForcedTeamName(p) == null && !nameTags.hasTeamHandlingPaused(p) && !nameTags.getDisableChecker().isDisabledPlayer(p)) {
-                for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer viewer : TAB.getInstance().getOnlineTabPlayers()) {
                     viewer.getScoreboard().unregisterTeam(previousShortName);
                 }
                 nameTags.registerTeam(p);
@@ -92,7 +92,7 @@ public class Sorting extends TabFeature implements SortingManager, JoinListener,
         nameTags = TAB.getInstance().getNameTagManager();
         layout = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.LAYOUT);
         redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             constructTeamNames(all);
         }
     }
@@ -165,7 +165,7 @@ public class Sorting extends TabFeature implements SortingManager, JoinListener,
      */
     private @NotNull String checkTeamName(@NotNull TabPlayer p, @NotNull StringBuilder currentName, int id) {
         String potentialTeamName = currentName.toString() + (char)id;
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             if (all == p) continue;
             if (shortTeamNames.get(all) != null && shortTeamNames.get(all).equals(potentialTeamName)) {
                 return checkTeamName(p, currentName, id+1);

--- a/shared/src/main/java/me/neznamy/tab/shared/placeholders/UniversalPlaceholderRegistry.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/placeholders/UniversalPlaceholderRegistry.java
@@ -45,7 +45,7 @@ public class UniversalPlaceholderRegistry {
         manager.registerPlayerPlaceholder(TabConstants.Placeholder.WORLD, -1, p -> ((TabPlayer)p).getWorld());
         manager.registerPlayerPlaceholder(TabConstants.Placeholder.WORLD_ONLINE, 1000, p -> {
             int count = 0;
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 if (((TabPlayer)p).getWorld().equals(player.getWorld()) && !player.isVanished()) count++;
             }
             return count;
@@ -53,7 +53,7 @@ public class UniversalPlaceholderRegistry {
         manager.registerPlayerPlaceholder(TabConstants.Placeholder.SERVER, -1, p -> ((TabPlayer)p).getServer());
         manager.registerPlayerPlaceholder(TabConstants.Placeholder.SERVER_ONLINE, 1000, p -> {
             int count = 0;
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 if (((TabPlayer)p).getServer().equals(player.getServer()) && !player.isVanished()) count++;
             }
             return count;
@@ -73,21 +73,21 @@ public class UniversalPlaceholderRegistry {
         manager.registerServerPlaceholder(TabConstants.Placeholder.MEMORY_MAX_GB, -1, () -> decimal2.format((float)Runtime.getRuntime().maxMemory()/1024/1024/1024));
         manager.registerServerPlaceholder(TabConstants.Placeholder.ONLINE, 1000, () -> {
             int count = 0;
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!player.isVanished()) count++;
             }
             return count;
         });
         manager.registerServerPlaceholder(TabConstants.Placeholder.STAFF_ONLINE, 2000, () -> {
             int count = 0;
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 if (player.hasPermission(TabConstants.Permission.STAFF) && !player.isVanished()) count++;
             }
             return count;
         });
         manager.registerServerPlaceholder(TabConstants.Placeholder.NON_STAFF_ONLINE, 2000, () -> {
             int count = 0;
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 if (!player.hasPermission(TabConstants.Permission.STAFF) && !player.isVanished()) count++;
             }
             return count;

--- a/shared/src/main/java/me/neznamy/tab/shared/placeholders/types/RelationalPlaceholderImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/placeholders/types/RelationalPlaceholderImpl.java
@@ -78,7 +78,7 @@ public class RelationalPlaceholderImpl extends TabPlaceholder implements Relatio
     @Override
     public void updateFromNested(@NonNull TabPlayer viewer) {
         Set<Refreshable> usage = TAB.getInstance().getPlaceholderManager().getPlaceholderUsage(identifier);
-        for (TabPlayer target : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer target : TAB.getInstance().getOnlineTabPlayers()) {
             Object value = request(viewer, target);
             String s = getReplacements().findReplacement(String.valueOf(value));
             lastValues.computeIfAbsent(viewer, v -> Collections.synchronizedMap(new WeakHashMap<>())).put(target, s);

--- a/shared/src/main/java/me/neznamy/tab/shared/placeholders/types/ServerPlaceholderImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/placeholders/types/ServerPlaceholderImpl.java
@@ -52,7 +52,7 @@ public class ServerPlaceholderImpl extends TabPlaceholder implements ServerPlace
     public void updateValue(@Nullable Object value) {
         if (hasValueChanged(value)) {
             for (Refreshable r : TAB.getInstance().getPlaceholderManager().getPlaceholderUsage(identifier)) {
-                for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
                     if (!all.isLoaded()) return; // Updated on join
                     long startTime = System.nanoTime();
                     r.refresh(all, false);
@@ -67,7 +67,7 @@ public class ServerPlaceholderImpl extends TabPlaceholder implements ServerPlace
 
         if (!ERROR_VALUE.equals(newValue) && !identifier.equals(newValue) && !lastValue.equals(newValue)) {
             lastValue = newValue;
-            for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+            for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                 updateParents(player);
                 TAB.getInstance().getPlaceholderManager().getTabExpansion().setPlaceholderValue(player, identifier, newValue);
             }

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/Scoreboard.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/Scoreboard.java
@@ -252,7 +252,7 @@ public abstract class Scoreboard<T extends TabPlayer> {
      */
     @Nullable
     public static TabPlayer getPlayer(@NotNull String name) {
-        for (TabPlayer p : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer p : TAB.getInstance().getOnlineTabPlayers()) {
             if (p.getNickname().equals(name))
                 return p; // Nicked name
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/impl/AdventureBossBar.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/impl/AdventureBossBar.java
@@ -1,6 +1,6 @@
 package me.neznamy.tab.shared.platform.impl;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -25,24 +25,28 @@ public class AdventureBossBar implements BossBar {
     private final TabPlayer player;
 
     /** BossBars currently visible to the player */
-    private final Map<UUID, net.kyori.adventure.bossbar.BossBar> bossBars = new LinkedHashMap<>();
+    private final Map<UUID, net.kyori.adventure.bossbar.BossBar> bossBars
+            = new HashMap<>();
 
     @Override
-    public void create(@NotNull UUID id, @NotNull String title, float progress, @NotNull BarColor color, @NotNull BarStyle style) {
-        if (bossBars.containsKey(id)) {
-            // Can happen on 1.20.2+ on Velocity on server switch
-            ((Audience)player.getPlayer()).hideBossBar(bossBars.get(id));
-            ((Audience)player.getPlayer()).showBossBar(bossBars.get(id));
-            return;
-        }
-        net.kyori.adventure.bossbar.BossBar bar = net.kyori.adventure.bossbar.BossBar.bossBar(
-                AdventureHook.toAdventureComponent(IChatBaseComponent.optimizedComponent(title), player.getVersion()),
-                progress,
-                Color.valueOf(color.name()),
-                Overlay.valueOf(style.name())
-        );
-        bossBars.put(id, bar);
-        ((Audience)player.getPlayer()).showBossBar(bar);
+    public void create(@NotNull UUID id,
+                       @NotNull String title,
+                       float progress, @NotNull BarColor color,
+                       @NotNull BarStyle style) {
+
+        Audience audience = (Audience) player.getPlayer();
+        audience.showBossBar(bossBars.compute(id, (k,v) -> {
+            if (v != null) {
+                audience.hideBossBar(v);
+                return v;
+            }
+            return net.kyori.adventure.bossbar.BossBar.bossBar(
+                    AdventureHook.toAdventureComponent(IChatBaseComponent.optimizedComponent(title), player.getVersion()),
+                    progress,
+                    Color.valueOf(color.name()),
+                    Overlay.valueOf(style.name())
+            );
+        }));
     }
 
     @Override

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/impl/AdventureBossBar.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/impl/AdventureBossBar.java
@@ -35,18 +35,22 @@ public class AdventureBossBar implements BossBar {
                        @NotNull BarStyle style) {
 
         Audience audience = (Audience) player.getPlayer();
-        audience.showBossBar(bossBars.compute(id, (k,v) -> {
-            if (v != null) {
-                audience.hideBossBar(v);
-                return v;
-            }
-            return net.kyori.adventure.bossbar.BossBar.bossBar(
-                    AdventureHook.toAdventureComponent(IChatBaseComponent.optimizedComponent(title), player.getVersion()),
-                    progress,
-                    Color.valueOf(color.name()),
-                    Overlay.valueOf(style.name())
-            );
-        }));
+
+        net.kyori.adventure.bossbar.BossBar prev = bossBars.get(id);
+        if (prev != null) {
+            // Can happen on 1.20.2+ on Velocity on server switch
+            audience.hideBossBar(prev);
+            audience.showBossBar(prev);
+            return;
+        }
+        net.kyori.adventure.bossbar.BossBar bar = net.kyori.adventure.bossbar.BossBar.bossBar(
+                AdventureHook.toAdventureComponent(IChatBaseComponent.optimizedComponent(title), player.getVersion()),
+                progress,
+                Color.valueOf(color.name()),
+                Overlay.valueOf(style.name())
+        );
+        bossBars.put(id, bar);
+        audience.showBossBar(bar);
     }
 
     @Override

--- a/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyPlatform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyPlatform.java
@@ -22,6 +22,7 @@ import me.neznamy.tab.shared.proxy.message.outgoing.RegisterPlaceholder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -36,7 +37,25 @@ import java.util.function.Supplier;
 public abstract class ProxyPlatform implements Platform {
 
     /** Registered plugin messages the plugin can receive from Bridge */
-    private final Map<String, Supplier<IncomingMessage>> registeredMessages = new HashMap<>();
+    private final static Map<String, Supplier<IncomingMessage>> registeredMessages;
+
+    static {
+        Map<String, Supplier<IncomingMessage>> m = new HashMap<>();
+        m.put("PlaceholderError", PlaceholderError::new);
+        m.put("UpdateGameMode", UpdateGameMode::new);
+        m.put("Permission", HasPermission::new);
+        m.put("Invisible", Invisible::new);
+        m.put("Disguised", Disguised::new);
+        m.put("Boat", OnBoat::new);
+        m.put("World", SetWorld::new);
+        m.put("Group", SetGroup::new);
+        m.put("Vanished", Vanished::new);
+        m.put("Placeholder", UpdatePlaceholder::new);
+        m.put("PlayerJoinResponse", PlayerJoinResponse::new);
+        m.put("RegisterPlaceholder", me.neznamy.tab.shared.proxy.message.incoming.RegisterPlaceholder::new);
+
+        registeredMessages = Collections.unmodifiableMap(m);
+    }
 
     /** Placeholders which are refreshed on backend server */
     private final Map<String, Integer> bridgePlaceholders = new ConcurrentHashMap<>();
@@ -44,20 +63,7 @@ public abstract class ProxyPlatform implements Platform {
     /**
      * Constructs new instance.
      */
-    protected ProxyPlatform() {
-        registeredMessages.put("PlaceholderError", PlaceholderError::new);
-        registeredMessages.put("UpdateGameMode", UpdateGameMode::new);
-        registeredMessages.put("Permission", HasPermission::new);
-        registeredMessages.put("Invisible", Invisible::new);
-        registeredMessages.put("Disguised", Disguised::new);
-        registeredMessages.put("Boat", OnBoat::new);
-        registeredMessages.put("World", SetWorld::new);
-        registeredMessages.put("Group", SetGroup::new);
-        registeredMessages.put("Vanished", Vanished::new);
-        registeredMessages.put("Placeholder", UpdatePlaceholder::new);
-        registeredMessages.put("PlayerJoinResponse", PlayerJoinResponse::new);
-        registeredMessages.put("RegisterPlaceholder", me.neznamy.tab.shared.proxy.message.incoming.RegisterPlaceholder::new);
-    }
+    protected ProxyPlatform() { }
 
     @Override
     public @NotNull GroupManager detectPermissionPlugin() {

--- a/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyPlatform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyPlatform.java
@@ -82,7 +82,7 @@ public abstract class ProxyPlatform implements Platform {
             String server = identifier.substring(8, identifier.length()-1);
             pl.registerServerPlaceholder(identifier, 1000, () -> {
                 int count = 0;
-                for (TabPlayer player : TAB.getInstance().getOnlinePlayers()) {
+                for (TabPlayer player : TAB.getInstance().getOnlineTabPlayers()) {
                     if (player.getServer().equals(server) && !player.isVanished()) count++;
                 }
                 return count;
@@ -97,7 +97,7 @@ public abstract class ProxyPlatform implements Platform {
             placeholder = pl.registerPlayerPlaceholder(identifier, -1, player -> null);
         }
         bridgePlaceholders.put(placeholder.getIdentifier(), refresh);
-        for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer all : TAB.getInstance().getOnlineTabPlayers()) {
             ((ProxyTabPlayer)all).sendPluginMessage(new RegisterPlaceholder(placeholder.getIdentifier(), refresh));
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyTabPlayer.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyTabPlayer.java
@@ -141,7 +141,7 @@ public abstract class ProxyTabPlayer extends TabPlayer {
     public boolean hasPermission(@NotNull String permission) {
         if (TAB.getInstance().getConfiguration().isBukkitPermissions()) {
             sendPluginMessage(new PermissionRequest(permission));
-            return permissions != null && permissions.getOrDefault(permission, false);
+            return permissions.getOrDefault(permission, false);
         }
         return hasPermission0(permission);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyTabPlayer.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyTabPlayer.java
@@ -141,7 +141,7 @@ public abstract class ProxyTabPlayer extends TabPlayer {
     public boolean hasPermission(@NotNull String permission) {
         if (TAB.getInstance().getConfiguration().isBukkitPermissions()) {
             sendPluginMessage(new PermissionRequest(permission));
-            return permissions.getOrDefault(permission, false);
+            return permissions != null && permissions.getOrDefault(permission, false);
         }
         return hasPermission0(permission);
     }

--- a/sponge7/src/main/java/me/neznamy/tab/platforms/sponge7/SpongeTabList.java
+++ b/sponge7/src/main/java/me/neznamy/tab/platforms/sponge7/SpongeTabList.java
@@ -87,7 +87,7 @@ public class SpongeTabList implements TabList {
 
     @Override
     public void checkDisplayNames() {
-        for (TabPlayer target : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer target : TAB.getInstance().getOnlineTabPlayers()) {
             player.getPlayer().getTabList().getEntry(target.getUniqueId()).ifPresent(entry -> {
                 Text expectedComponent = expectedDisplayNames.get(target);
                 if (expectedComponent != null && entry.getDisplayName().orElse(null) != expectedComponent) {

--- a/sponge8/src/main/java/me/neznamy/tab/platforms/sponge8/SpongeTabList.java
+++ b/sponge8/src/main/java/me/neznamy/tab/platforms/sponge8/SpongeTabList.java
@@ -88,7 +88,7 @@ public class SpongeTabList implements TabList {
 
     @Override
     public void checkDisplayNames() {
-        for (TabPlayer target : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer target : TAB.getInstance().getOnlineTabPlayers()) {
             player.getPlayer().tabList().entry(target.getUniqueId()).ifPresent(entry -> {
                 Component expectedComponent = expectedDisplayNames.get(target);
                 if (expectedComponent != null && entry.displayName().orElse(null) != expectedComponent) {

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTabList.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTabList.java
@@ -104,7 +104,7 @@ public class VelocityTabList implements TabList {
 
     @Override
     public void checkDisplayNames() {
-        for (TabPlayer target : TAB.getInstance().getOnlinePlayers()) {
+        for (TabPlayer target : TAB.getInstance().getOnlineTabPlayers()) {
             player.getPlayer().getTabList().getEntry(target.getUniqueId()).ifPresent(entry -> {
                 Component expectedComponent = expectedDisplayNames.get(target);
                 if (expectedComponent != null && entry.getDisplayNameComponent().orElse(null) != expectedComponent) {


### PR DESCRIPTION
Cleaned up the code a little, got rid of unnecessary calls to HashMap, changed implementations a little, etc.

What really matters is the API
Passing an array to users is a very bad idea
(getOnlinePlayers())

Firstly, if we really want to transfer an array, then we will always have to copy it, because at any moment it may turn out that someone has changed the array that we are transferring. This is a very bad practice, while we have total Copy On Write, and also Copy On Read

Secondly, it is advisable to get rid of all null returns and use, for example, java.util.Optional, but this is if you are not afraid about backward compatibility, and you haven’t touched it, changed or deleted anything, except that you marked getOnlinePlayers as " Deprecated"

Also, it is advisable to work completely with the api, and not with the implementation, but this is the future, the future