### PR TITLE
Fix SpongeForge startup crash

### DIFF
--- a/sponge8/src/main/java/me/neznamy/tab/platforms/sponge8/Sponge8TAB.java
+++ b/sponge8/src/main/java/me/neznamy/tab/platforms/sponge8/Sponge8TAB.java
@@ -15,6 +15,7 @@ import org.spongepowered.api.event.lifecycle.RegisterCommandEvent;
 import org.spongepowered.api.event.lifecycle.StartingEngineEvent;
 import org.spongepowered.api.event.lifecycle.StoppingEngineEvent;
 import org.spongepowered.plugin.PluginContainer;
+import org.spongepowered.plugin.builtin.jvm.Plugin;
 
 import java.nio.file.Path;
 
@@ -22,6 +23,7 @@ import java.nio.file.Path;
  * Main class for Sponge 8.
  */
 @Getter
+@Plugin("tab")
 public class Sponge8TAB {
 
     @Inject @ConfigDir(sharedRoot = false) private Path configDir;

--- a/sponge8/src/main/java/me/neznamy/tab/platforms/sponge8/Sponge8TAB.java
+++ b/sponge8/src/main/java/me/neznamy/tab/platforms/sponge8/Sponge8TAB.java
@@ -23,7 +23,7 @@ import java.nio.file.Path;
  * Main class for Sponge 8.
  */
 @Getter
-@Plugin("tab")
+@Plugin(TabConstants.PLUGIN_ID)
 public class Sponge8TAB {
 
     @Inject @ConfigDir(sharedRoot = false) private Path configDir;


### PR DESCRIPTION
SpongeForge crashes with the following message `File /path/to/plugin/TAB.v4.1.2.jar constructed 0 mods: [], but had 1 mods specified: [tab]`

I have tested the following versions:
- 1.16.5-36.2.5-8.2.1-RC1459
- 1.16.5-36.2.5-8.2.0

This can be fixed by putting an `@Plugin("tab")` annotation on the main Sponge 8 class.