### PR TITLE
[GitHub] Add build number to artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,35 +8,34 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 #https://github.com/actions/checkout/releases
+      - uses: actions/checkout@v4 # https://github.com/actions/checkout/releases
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v4 #https://github.com/actions/setup-java/releases
+        uses: actions/setup-java@v4 # https://github.com/actions/setup-java/releases
         with:
           distribution: 'temurin'
           java-version: 21
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4.0.2 #https://github.com/actions/cache/releases
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
       - name: Cache Gradle
-        uses: actions/cache@v4.0.2 #https://github.com/actions/cache/releases
+        uses: actions/cache@v4.0.2 # https://github.com/actions/cache/releases
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: "${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}"
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Build and analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
         run: ./gradlew clean build
+      - name: Rename JAR with Build Number
+        run: |
+          original_jar=$(find jar/build/libs -type f -name "TAB-*.jar")
+          new_name=$(echo "$original_jar" | sed "s/TAB-\(.*\)\.jar/TAB-\1+${{ github.run_number }}.jar/")
+          mv "$original_jar" "$new_name"
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.3 #https://github.com/actions/upload-artifact/releases
+        uses: actions/upload-artifact@v4.3.3 # https://github.com/actions/upload-artifact/releases
         with:
           name: Click here to download
-          path: jar/build/libs/TAB-**.jar
+          path: jar/build/libs/TAB-*+${{ github.run_number }}.jar


### PR DESCRIPTION
This PR adds the GitHub build number at the end of the file. This makes it easier to organize and track updates for people that use GitHub actions to download the plugin.

Example:
- Previous output: TAB-5.0.0-SNAPSHOT
- New output: TAB-5.0.0-SNAPSHOT+5