### PR TITLE
Add a signed_texture skin parameter to avoid an API call

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SignedTexture.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SignedTexture.java
@@ -1,0 +1,27 @@
+
+package me.neznamy.tab.shared.features.layout.skin;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import me.neznamy.tab.shared.config.file.ConfigurationFile;
+
+/**
+ * Skin source using raw texture;signature.
+ */
+public class SignedTexture extends SkinSource {
+
+    protected SignedTexture(@NotNull ConfigurationFile file) {
+        super(file, "signed_textures");
+    }
+
+    @Override
+    @NotNull
+    public List<String> download(@NotNull String textureBase64) {
+        String[] parts = textureBase64.split(";");
+        String base64 = parts[0];
+        String signature = parts[1];
+        return Arrays.asList(base64, signature);
+    }
+}

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SignedTexture.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SignedTexture.java
@@ -21,7 +21,7 @@ public class SignedTexture extends SkinSource {
     public List<String> download(@NotNull String textureBase64) {
         String[] parts = textureBase64.split(";");
         String base64 = parts[0];
-        String signature = parts[1];
+        String signature = parts.length > 1 ? parts[1] : "";
         return Arrays.asList(base64, signature);
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SkinManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/skin/SkinManager.java
@@ -49,6 +49,7 @@ public class SkinManager {
                 sources.put("player", new PlayerSkin(cache));
                 sources.put("mineskin", new MineSkin(cache));
                 sources.put("texture", new Texture(cache));
+                sources.put("signed_texture", new SignedTexture(cache));
                 this.defaultSkin = getSkin(defaultSkin);
                 for (Map.Entry<Integer, String> entry : defaultSkinHashMap.entrySet()) {
                     Skin skin = getSkin(entry.getValue());
@@ -87,10 +88,13 @@ public class SkinManager {
         if (invalidSkins.contains(skin)) return defaultSkin;
         for (Entry<String, SkinSource> entry : sources.entrySet()) {
             if (skin.startsWith(entry.getKey() + ":")) {
-                List<String> value = entry.getValue().getSkin(skin.substring(entry.getKey().length()+1));
+                List<String> value = entry.getValue().getSkin(skin.substring(entry.getKey().length() + 1));
                 if (value.isEmpty()) {
                     invalidSkins.add(skin);
                     return defaultSkin;
+                }
+                if (value.size() == 1) {
+                    return new Skin(value.get(0), null);
                 }
                 return new Skin(value.get(0), value.get(1));
             }


### PR DESCRIPTION
I'm adding a `signed_texture` parameter in the skin retrieval process, **which avoids an API call**. For this, I use `signed_texture:texture;signature` in the skin retrieval.