### PR TITLE
[Layout] prevent layout switching from causing tablist to flicker on simple changes

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/FixedSlot.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/FixedSlot.java
@@ -23,11 +23,11 @@ public class FixedSlot extends RefreshableFeature {
     @NonNull private final LayoutManagerImpl manager;
     @Getter private final int slot;
     @NonNull private final LayoutPattern pattern;
-    @NonNull private final UUID id;
+    @Getter @NonNull private final UUID id;
     @NonNull private final String text;
-    @NonNull private final String propertyName;
+    @Getter @NonNull private final String propertyName;
     @NonNull private final String skin;
-    @NonNull private final String skinProperty;
+    @Getter @NonNull private final String skinProperty;
     private final int ping;
 
     public FixedSlot(@NonNull LayoutManagerImpl manager, int slot, @NonNull LayoutPattern pattern, @NonNull UUID id,
@@ -75,6 +75,19 @@ public class FixedSlot extends RefreshableFeature {
                 0,
                 cache.get(viewer.getProperty(propertyName).updateAndGet())
         );
+    }
+
+    /**
+     * Update an existing entry from this slot for given viewer. This doesn't work for skins!
+     *
+     * @param viewer
+     * Player viewing the slot
+     */
+    public void updateEntry(@NotNull TabPlayer viewer) {
+        viewer.setProperty(this, propertyName, text);
+        viewer.setProperty(this, skinProperty, skin);
+        viewer.getTabList().updateDisplayName(id, cache.get(viewer.getProperty(propertyName).updateAndGet()));
+        viewer.getTabList().updateLatency(id, ping);
     }
 
     /**

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/FixedSlot.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/FixedSlot.java
@@ -80,14 +80,24 @@ public class FixedSlot extends RefreshableFeature {
     /**
      * Update an existing entry from this slot for given viewer. This doesn't work for skins!
      *
-     * @param viewer
-     * Player viewing the slot
+     * @param   viewer
+     *          Player viewing the slot
+     * @return  returns false if update unsuccessful, otherwise returns true
      */
-    public void updateEntry(@NotNull TabPlayer viewer) {
+    public boolean updateEntry(@NotNull TabPlayer viewer, LayoutView previousLayout) {
+        if (previousLayout == null || !viewer.getTabList().containsEntry(id)) {
+            return false;
+        }
+        FixedSlot previousSlot = previousLayout.getFixedSlots().stream().filter(x -> x.getId() == id).findAny().orElse(null);
+        // Fail if previousSlot skin doesn't equal new skin
+        if (previousSlot == null || !previousSlot.skinProperty.equals(skinProperty)) {
+            return false;
+        }
         viewer.setProperty(this, propertyName, text);
         viewer.setProperty(this, skinProperty, skin);
         viewer.getTabList().updateDisplayName(id, cache.get(viewer.getProperty(propertyName).updateAndGet()));
         viewer.getTabList().updateLatency(id, ping);
+        return true;
     }
 
     /**

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
@@ -143,12 +143,12 @@ public class LayoutManagerImpl extends RefreshableFeature implements LayoutManag
         LayoutView current = p.layoutData.view;
         String currentName = current == null ? null : current.getPattern().getName();
         if (!Objects.equals(highestName, currentName)) {
-            // if (current != null) current.destroy();
             if (highest != null) {
                 LayoutView view = new LayoutView(this, highest, p);
                 view.send(current);
                 p.layoutData.view = view;
             } else {
+                if (current != null) current.destroy();
                 p.layoutData.view = null;
             }
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutManagerImpl.java
@@ -143,12 +143,13 @@ public class LayoutManagerImpl extends RefreshableFeature implements LayoutManag
         LayoutView current = p.layoutData.view;
         String currentName = current == null ? null : current.getPattern().getName();
         if (!Objects.equals(highestName, currentName)) {
-            if (current != null) current.destroy();
-            p.layoutData.view = null;
+            // if (current != null) current.destroy();
             if (highest != null) {
                 LayoutView view = new LayoutView(this, highest, p);
-                view.send();
+                view.send(current);
                 p.layoutData.view = view;
+            } else {
+                p.layoutData.view = null;
             }
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutView.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/LayoutView.java
@@ -48,16 +48,9 @@ public class LayoutView {
         for (ParentGroup group : groups) {
             group.sendSlots();
         }
-        final Collection<FixedSlot> previousSlots = previous == null ? null : previous.getFixedSlots();
-        final List<UUID> previousSlotsUUIDS = previousSlots == null ? Collections.emptyList() : previousSlots.stream().map(x -> x.getId()).collect(Collectors.toList());
         for (FixedSlot slot : fixedSlots) {
-            if (previousSlotsUUIDS.contains(slot.getId()) && viewer.getTabList().containsEntry(slot.getId())) {
-                // only use updateEntry if the previous skin was the same
-                FixedSlot previousSlot = previousSlots.stream().filter(x -> x.getId() == slot.getId()).findAny().orElse(null);
-                if (previousSlot != null && slot.getSkinProperty().equals(previousSlot.getSkinProperty())) {
-                    slot.updateEntry(viewer);
-                    continue;
-                }
+            if (slot.updateEntry(viewer, previous)) {
+                continue;
             }
             viewer.getTabList().removeEntry(slot.getId());
             viewer.getTabList().addEntry(slot.createEntry(viewer));
@@ -91,6 +84,9 @@ public class LayoutView {
     }
 
     public void tick() {
+        if (groups.isEmpty()) {
+            return;
+        }
         Stream<TabPlayer> str = manager.getSortedPlayers().keySet().stream().filter(
                 player -> TAB.getInstance().getPlatform().canSee(viewer, player));
         List<TabPlayer> players = str.collect(Collectors.toList());

--- a/shared/src/main/java/me/neznamy/tab/shared/features/layout/ParentGroup.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/layout/ParentGroup.java
@@ -3,6 +3,7 @@ package me.neznamy.tab.shared.features.layout;
 import java.util.*;
 
 import lombok.Getter;
+import me.neznamy.tab.shared.platform.TabList;
 import me.neznamy.tab.shared.platform.TabPlayer;
 import me.neznamy.tab.shared.placeholders.conditions.Condition;
 import org.jetbrains.annotations.NotNull;
@@ -49,10 +50,12 @@ public class ParentGroup {
             }
         }
     }
-    
+
     public void sendSlots() {
         for (PlayerSlot s : playerSlots.values()) {
-            viewer.getTabList().addEntry(s.getSlot(viewer));
+            TabList.Entry entry = s.getSlot(viewer);
+            viewer.getTabList().removeEntry(entry.getUniqueId());
+            viewer.getTabList().addEntry(entry);
         }
     }
 }


### PR DESCRIPTION
Display name and latency changes can be updated without flickering.
Skins changes still need to be removed/added, which causes flickering.

- ~~ParentGroup is not tested very well, there may be some edgecases.~~