### PR TITLE
Get skin from profile properties by property name

### DIFF
--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeeTabPlayer.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeeTabPlayer.java
@@ -93,8 +93,13 @@ public class BungeeTabPlayer extends ProxyTabPlayer {
         LoginResult loginResult = ((InitialHandler)getPlayer().getPendingConnection()).getLoginProfile();
         if (loginResult == null) return null;
         Property[] properties = loginResult.getProperties();
-        if (properties == null || properties.length == 0) return null; //Offline mode
-        return new TabList.Skin(properties[0].getValue(), properties[0].getSignature());
+        if (properties == null) return null; //Offline mode
+        for (Property property : properties) {
+            if (property.getName().equals(TabList.TEXTURES_PROPERTY)) {
+                return new TabList.Skin(property.getValue(), property.getSignature());
+            }
+        }
+        return null;
     }
 
     @Override

--- a/sponge8/src/main/java/me/neznamy/tab/platforms/sponge8/SpongeTabPlayer.java
+++ b/sponge8/src/main/java/me/neznamy/tab/platforms/sponge8/SpongeTabPlayer.java
@@ -84,7 +84,12 @@ public class SpongeTabPlayer extends BackendTabPlayer {
     public TabList.Skin getSkin() {
         List<ProfileProperty> list = getPlayer().profile().properties();
         if (list.isEmpty()) return null; // Offline mode
-        return new TabList.Skin(list.get(0).value(), list.get(0).signature().orElse(null));
+        for (ProfileProperty property : list) {
+            if (property.name().equals(TabList.TEXTURES_PROPERTY)) {
+                return new TabList.Skin(property.value(), property.signature().orElse(null));
+            }
+        }
+        return null;
     }
 
     @Override

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTabPlayer.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTabPlayer.java
@@ -65,7 +65,12 @@ public class VelocityTabPlayer extends ProxyTabPlayer {
     public TabList.Skin getSkin() {
         List<GameProfile.Property> properties = getPlayer().getGameProfile().getProperties();
         if (properties.isEmpty()) return null; //Offline mode
-        return new TabList.Skin(properties.get(0).getValue(), properties.get(0).getSignature());
+        for (GameProfile.Property property : properties) {
+            if (property.getName().equals(TabList.TEXTURES_PROPERTY)) {
+                return new TabList.Skin(property.getValue(), property.getSignature());
+            }
+        }
+        return null;
     }
     
     @Override


### PR DESCRIPTION
The current implementation of `getSkin()` on some platforms simply takes the first property of the profile properties as the skin texture, which can cause problems if multiple properties are returned and the skin texture is not the first. Therefore, it may be better to get the skin texture by property name to ensure that other properties won't be mistaken for the skin texture.