### PR TITLE
feat: sayanvanish support

### DIFF
--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
         exclude("net.md-5", "bungeecord-chat")
     }
     compileOnly("com.github.LeonMangler:PremiumVanishAPI:2.8.8")
+    compileOnly("org.sayandev:sayanvanish-bukkit:1.5.0-SNAPSHOT")
 }

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/hook/BukkitSayanVanishHook.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/hook/BukkitSayanVanishHook.java
@@ -1,0 +1,26 @@
+package me.neznamy.tab.platforms.bukkit.hook;
+
+import me.neznamy.tab.platforms.bukkit.BukkitTabPlayer;
+import me.neznamy.tab.shared.hook.SayanVanishHook;
+import me.neznamy.tab.shared.platform.TabPlayer;
+import org.jetbrains.annotations.NotNull;
+import org.sayandev.sayanvanish.bukkit.api.BukkitUser;
+import org.sayandev.sayanvanish.bukkit.api.SayanVanishBukkitAPI;
+
+/**
+ * SayanVanish hook for Bukkit.
+ */
+public class BukkitSayanVanishHook extends SayanVanishHook {
+
+    @Override
+    public boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        BukkitUser viewerUser = SayanVanishBukkitAPI.getInstance().getUser(viewer.getUniqueId());
+        BukkitUser targetUser = SayanVanishBukkitAPI.getOrCreateUser(((BukkitTabPlayer)target).getPlayer());
+        return SayanVanishBukkitAPI.getInstance().canSee(viewerUser, targetUser);
+    }
+
+    @Override
+    public boolean isVanished(@NotNull TabPlayer player) {
+        return SayanVanishBukkitAPI.getInstance().isVanished(player.getUniqueId());
+    }
+}

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
@@ -5,6 +5,7 @@ import me.clip.placeholderapi.PlaceholderAPI;
 import me.neznamy.tab.platforms.bukkit.*;
 import me.neznamy.tab.platforms.bukkit.entity.PacketEntityView;
 import me.neznamy.tab.platforms.bukkit.hook.BukkitPremiumVanishHook;
+import me.neznamy.tab.platforms.bukkit.hook.BukkitSayanVanishHook;
 import me.neznamy.tab.platforms.bukkit.nms.BukkitReflection;
 import me.neznamy.tab.platforms.bukkit.nms.ComponentConverter;
 import me.neznamy.tab.platforms.bukkit.nms.PingRetriever;
@@ -30,6 +31,7 @@ import me.neznamy.tab.shared.features.bossbar.BossBarManagerImpl;
 import me.neznamy.tab.shared.features.nametags.NameTag;
 import me.neznamy.tab.shared.hook.LuckPermsHook;
 import me.neznamy.tab.shared.hook.PremiumVanishHook;
+import me.neznamy.tab.shared.hook.SayanVanishHook;
 import me.neznamy.tab.shared.placeholders.types.PlayerPlaceholderImpl;
 import me.neznamy.tab.shared.placeholders.expansion.EmptyTabExpansion;
 import me.neznamy.tab.shared.placeholders.expansion.TabExpansion;
@@ -93,6 +95,9 @@ public class BukkitPlatform implements BackendPlatform {
         }
         if (Bukkit.getPluginManager().isPluginEnabled("PremiumVanish")) {
             PremiumVanishHook.setInstance(new BukkitPremiumVanishHook());
+        }
+        if (Bukkit.getPluginManager().isPluginEnabled("SayanVanish")) {
+            SayanVanishHook.setInstance(new BukkitSayanVanishHook());
         }
         ComponentConverter.tryLoad();
         PacketEntityView.tryLoad();

--- a/bungeecord/build.gradle.kts
+++ b/bungeecord/build.gradle.kts
@@ -4,4 +4,5 @@ dependencies {
     compileOnly("net.md-5:bungeecord-proxy:1.20-R0.3-SNAPSHOT")
     compileOnly("com.github.limework.redisbungee:RedisBungee-Bungee:0.11.0")
     compileOnly("com.github.LeonMangler:PremiumVanishAPI:2.8.8")
+    compileOnly("org.sayandev:sayanvanish-proxy-bungeecord:1.5.0-SNAPSHOT")
 }

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
@@ -3,12 +3,14 @@ package me.neznamy.tab.platforms.bungeecord;
 import com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI;
 import me.neznamy.tab.platforms.bungeecord.features.BungeeRedisSupport;
 import me.neznamy.tab.platforms.bungeecord.hook.BungeePremiumVanishHook;
+import me.neznamy.tab.platforms.bungeecord.hook.BungeeSayanVanishHook;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.*;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.hook.PremiumVanishHook;
+import me.neznamy.tab.shared.hook.SayanVanishHook;
 import me.neznamy.tab.shared.proxy.ProxyPlatform;
 import me.neznamy.tab.shared.util.ReflectionUtils;
 import net.md_5.bungee.api.ChatColor;
@@ -44,6 +46,9 @@ public class BungeePlatform extends ProxyPlatform {
         this.plugin = plugin;
         if (ProxyServer.getInstance().getPluginManager().getPlugin("PremiumVanish") != null) {
             PremiumVanishHook.setInstance(new BungeePremiumVanishHook(this));
+        }
+        if (ProxyServer.getInstance().getPluginManager().getPlugin("SayanVanish") != null) {
+            SayanVanishHook.setInstance(new BungeeSayanVanishHook());
         }
     }
 

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeeTabPlayer.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeeTabPlayer.java
@@ -10,6 +10,7 @@ import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.TabComponent;
 import me.neznamy.tab.shared.hook.PremiumVanishHook;
+import me.neznamy.tab.shared.hook.SayanVanishHook;
 import me.neznamy.tab.shared.platform.TabList;
 import me.neznamy.tab.shared.platform.BossBar;
 import me.neznamy.tab.shared.proxy.ProxyTabPlayer;
@@ -133,6 +134,7 @@ public class BungeeTabPlayer extends ProxyTabPlayer {
     @Override
     public boolean isVanished() {
         if (PremiumVanishHook.getInstance() != null && PremiumVanishHook.getInstance().isVanished(this)) return true;
+        if (SayanVanishHook.getInstance() != null && SayanVanishHook.getInstance().isVanished(this)) return true;
         return super.isVanished();
     }
 

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/hook/BungeeSayanVanishHook.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/hook/BungeeSayanVanishHook.java
@@ -1,0 +1,26 @@
+package me.neznamy.tab.platforms.bungeecord.hook;
+
+import me.neznamy.tab.platforms.bungeecord.BungeeTabPlayer;
+import me.neznamy.tab.shared.hook.SayanVanishHook;
+import me.neznamy.tab.shared.platform.TabPlayer;
+import org.jetbrains.annotations.NotNull;
+import org.sayandev.sayanvanish.bungeecord.api.BungeeUser;
+import org.sayandev.sayanvanish.bungeecord.api.SayanVanishBungeeAPI;
+
+/**
+ * SayanVanish hook for BungeeCord.
+ */
+public class BungeeSayanVanishHook extends SayanVanishHook {
+
+    @Override
+    public boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        BungeeUser viewerUser = SayanVanishBungeeAPI.getInstance().getUser(viewer.getUniqueId());
+        BungeeUser targetUser = SayanVanishBungeeAPI.getOrCreateUser(((BungeeTabPlayer)target).getPlayer());
+        return SayanVanishBungeeAPI.getInstance().canSee(viewerUser, targetUser);
+    }
+
+    @Override
+    public boolean isVanished(@NotNull TabPlayer player) {
+        return SayanVanishBungeeAPI.getInstance().isVanished(player.getUniqueId());
+    }
+}

--- a/bungeecord/src/main/resources/bungee.yml
+++ b/bungeecord/src/main/resources/bungee.yml
@@ -4,4 +4,4 @@ version: @version@
 author: @author@
 description: @description@
 depends: []
-softDepends: [RedisBungee, LuckPerms, PremiumVanish]
+softDepends: [RedisBungee, LuckPerms, PremiumVanish, SayanVanish]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
         maven("https://repo.purpurmc.org/snapshots") // Purpur
         maven("https://repo.spongepowered.org/repository/maven-public/") // Sponge
         maven("https://jitpack.io") // PremiumVanish, Vault, YamlAssist, RedisBungee
+        maven("https://repo.sayandev.org/snapshots") // SayanVanish
         maven("https://repo.md-5.net/content/groups/public/") // LibsDisguises
         maven("https://nexus.codecrafter47.dyndns.eu/content/repositories/public/") // BungeeCord-proxy // I feel bad for doing this
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/hook/SayanVanishHook.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/hook/SayanVanishHook.java
@@ -1,0 +1,40 @@
+package me.neznamy.tab.shared.hook;
+
+import lombok.Getter;
+import lombok.Setter;
+import me.neznamy.tab.shared.platform.TabPlayer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Class for hooking into SayanVanish to get vanish status of players.
+ */
+public abstract class SayanVanishHook {
+
+    /** Instance of the class, if SayanVanish is available */
+    @Nullable
+    @Getter
+    @Setter
+    private static SayanVanishHook instance;
+
+    /**
+     * Returns {@code true} if {@code viewer} can see the {@code target} player,
+     * {@code false} if not.
+     *
+     * @param   viewer
+     *          Viewing player
+     * @param   target
+     *          Player who is being viewed
+     * @return  {@code true} if can see, {@code false} if not.
+     */
+    public abstract boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target);
+
+    /**
+     * Returns {@code true} if player is vanished, {@code false} if not.
+     *
+     * @param   player
+     *          Player to check
+     * @return  {@code true} if player is vanished, {@code false} if not.
+     */
+    public abstract boolean isVanished(@NotNull TabPlayer player);
+}

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
@@ -9,6 +9,7 @@ import me.neznamy.tab.shared.features.nametags.NameTag;
 import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.features.types.TabFeature;
 import me.neznamy.tab.shared.hook.PremiumVanishHook;
+import me.neznamy.tab.shared.hook.SayanVanishHook;
 import me.neznamy.tab.shared.placeholders.expansion.TabExpansion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -169,6 +170,7 @@ public interface Platform {
      */
     default boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
         if (PremiumVanishHook.getInstance() != null && PremiumVanishHook.getInstance().canSee(viewer, target)) return true;
+        if (SayanVanishHook.getInstance() != null && SayanVanishHook.getInstance().canSee(viewer, target)) return true;
         return !target.isVanished() || viewer.hasPermission(TabConstants.Permission.SEE_VANISHED);
     }
 }

--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     compileOnly("com.velocitypowered:velocity-api:3.2.0-SNAPSHOT")
     annotationProcessor("com.velocitypowered:velocity-api:3.2.0-SNAPSHOT")
     compileOnly("com.github.LeonMangler:PremiumVanishAPI:2.9.0-4")
+    compileOnly("org.sayandev:sayanvanish-proxy-velocity:1.5.0-SNAPSHOT")
 }
 
 tasks.compileJava {

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
@@ -7,6 +7,7 @@ import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import lombok.Getter;
 import me.neznamy.tab.platforms.velocity.features.VelocityRedisSupport;
 import me.neznamy.tab.platforms.velocity.hook.VelocityPremiumVanishHook;
+import me.neznamy.tab.platforms.velocity.hook.VelocitySayanVanishHook;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.TabComponent;
@@ -14,6 +15,7 @@ import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.hook.AdventureHook;
 import me.neznamy.tab.shared.hook.PremiumVanishHook;
+import me.neznamy.tab.shared.hook.SayanVanishHook;
 import me.neznamy.tab.shared.proxy.ProxyPlatform;
 import me.neznamy.tab.shared.util.ReflectionUtils;
 import net.kyori.adventure.text.Component;
@@ -50,6 +52,9 @@ public class VelocityPlatform extends ProxyPlatform {
         this.plugin = plugin;
         if (plugin.getServer().getPluginManager().isLoaded("premiumvanish")) {
             PremiumVanishHook.setInstance(new VelocityPremiumVanishHook());
+        }
+        if (plugin.getServer().getPluginManager().isLoaded("sayanvanish")) {
+            SayanVanishHook.setInstance(new VelocitySayanVanishHook());
         }
     }
 

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTAB.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTAB.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
+import com.velocitypowered.api.plugin.Dependency;
 import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
@@ -27,7 +28,11 @@ import java.nio.file.Path;
         version = TabConstants.PLUGIN_VERSION,
         description = TabConstants.PLUGIN_DESCRIPTION,
         url = TabConstants.PLUGIN_WEBSITE,
-        authors = TabConstants.PLUGIN_AUTHOR
+        authors = TabConstants.PLUGIN_AUTHOR,
+        dependencies = {
+                @Dependency(id = "premiumvanish", optional = true),
+                @Dependency(id = "sayanvanish", optional = true),
+        }
 )
 @Getter
 public class VelocityTAB {

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/hook/VelocitySayanVanishHook.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/hook/VelocitySayanVanishHook.java
@@ -1,0 +1,29 @@
+package me.neznamy.tab.platforms.velocity.hook;
+
+import lombok.extern.java.Log;
+import me.neznamy.tab.platforms.velocity.VelocityTabPlayer;
+import me.neznamy.tab.shared.hook.SayanVanishHook;
+import me.neznamy.tab.shared.platform.TabPlayer;
+import org.jetbrains.annotations.NotNull;
+import org.sayandev.sayanvanish.velocity.api.SayanVanishVelocityAPI;
+import org.sayandev.sayanvanish.velocity.api.VelocityUser;
+
+import java.util.logging.Logger;
+
+/**
+ * SayanVanish hook for Velocity.
+ */
+public class VelocitySayanVanishHook extends SayanVanishHook {
+
+    @Override
+    public boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        VelocityUser viewerUser = SayanVanishVelocityAPI.getInstance().getUser(viewer.getUniqueId());
+        VelocityUser targetUser = SayanVanishVelocityAPI.getOrCreateUser(((VelocityTabPlayer)target).getPlayer());
+        return SayanVanishVelocityAPI.getInstance().canSee(viewerUser, targetUser);
+    }
+
+    @Override
+    public boolean isVanished(@NotNull TabPlayer player) {
+        return SayanVanishVelocityAPI.getInstance().isVanished(player.getUniqueId());
+    }
+}


### PR DESCRIPTION
Some users of the SayanVanish plugin have reported bugs related to how TAB handles vanished players. While TAB does remove vanished users from the tab list even without this PR, I believe adding direct support for SayanVanish will help reduce unexpected behaviors.

With this PR, TAB still doesn't remove vanished users if the `layout` mode is enabled or if TAB is installed on Velocity with a shared tab list between multiple servers, and the vanished player is on a different server than the viewer. I'm uncertain if the SayanVanish hook is implemented correctly or if TAB inherently doesn't support vanished users under these specific conditions.