### PR TITLE
feat: add VanishIntegration api

### DIFF
--- a/api/src/main/java/me/neznamy/tab/api/integration/VanishIntegration.java
+++ b/api/src/main/java/me/neznamy/tab/api/integration/VanishIntegration.java
@@ -1,0 +1,87 @@
+package me.neznamy.tab.api.integration;
+
+import lombok.Getter;
+import me.neznamy.tab.api.TabPlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public abstract class VanishIntegration {
+
+    // Name of the plugin this integration is associated with
+    @NotNull
+    String plugin;
+
+    // Constructor to initialize the plugin name
+    public VanishIntegration(@NotNull String plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Determines if a viewer can see a target player.
+     *
+     * @param   viewer
+     *          The player attempting to view another player
+     * @param   target
+     *          The player being viewed
+     * @return  {@code true} if the viewer can see the target, {@code false} otherwise
+     */
+    public abstract boolean canSee(TabPlayer viewer, TabPlayer target);
+
+    /**
+     * Checks if the specified player is in a vanished state.
+     *
+     * @param   player
+     *          The player to check
+     * @return  {@code true} if the player is vanished, {@code false} otherwise
+     */
+    public abstract boolean isVanished(TabPlayer player);
+
+    /**
+     * Registers this integration handler to the global list of handlers.
+     */
+    public void register() {
+        registerHandler(this);
+    }
+
+    /**
+     * Unregisters this integration handler from the global list of handlers.
+     */
+    public void unregister() {
+        unregisterHandler(this);
+    }
+
+    /**
+     * Adds a VanishIntegration handler to the global list of handlers.
+     *
+     * @param handler
+     *        The handler to register
+     */
+    public static void registerHandler(VanishIntegration handler) {
+        HANDLERS.add(handler);
+    }
+
+    /**
+     * Removes a VanishIntegration handler from the global list of handlers.
+     *
+     * @param handler
+     *        The handler to unregister
+     */
+    public static void unregisterHandler(VanishIntegration handler) {
+        HANDLERS.remove(handler);
+    }
+
+    // A list of all registered VanishIntegration handlers
+    private static final List<VanishIntegration> HANDLERS = new ArrayList<>();
+
+    /**
+     * Retrieves the list of all registered VanishIntegration handlers.
+     *
+     * @return  A list of registered VanishIntegration handlers
+     */
+    public static List<VanishIntegration> getHandlers() {
+        return HANDLERS;
+    }
+}

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/hook/BukkitPremiumVanishHook.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/hook/BukkitPremiumVanishHook.java
@@ -1,10 +1,9 @@
 package me.neznamy.tab.platforms.bukkit.hook;
 
 import de.myzelyam.api.vanish.VanishAPI;
+import me.neznamy.tab.api.TabPlayer;
 import me.neznamy.tab.platforms.bukkit.BukkitTabPlayer;
 import me.neznamy.tab.shared.hook.PremiumVanishHook;
-import me.neznamy.tab.shared.platform.TabPlayer;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * PremiumVanish hook for Bukkit.
@@ -12,12 +11,12 @@ import org.jetbrains.annotations.NotNull;
 public class BukkitPremiumVanishHook extends PremiumVanishHook {
 
     @Override
-    public synchronized boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+    public boolean canSee(TabPlayer viewer, TabPlayer target) {
         return VanishAPI.canSee(((BukkitTabPlayer)viewer).getPlayer(), ((BukkitTabPlayer)target).getPlayer());
     }
 
     @Override
-    public boolean isVanished(@NotNull TabPlayer player) {
+    public boolean isVanished(TabPlayer player) {
         return VanishAPI.isInvisible(((BukkitTabPlayer)player).getPlayer());
     }
 }

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
@@ -29,7 +29,6 @@ import me.neznamy.tab.shared.features.PlaceholderManagerImpl;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.types.TabFeature;
 import me.neznamy.tab.shared.hook.LuckPermsHook;
-import me.neznamy.tab.shared.hook.PremiumVanishHook;
 import me.neznamy.tab.shared.placeholders.expansion.EmptyTabExpansion;
 import me.neznamy.tab.shared.placeholders.expansion.TabExpansion;
 import me.neznamy.tab.shared.placeholders.types.PlayerPlaceholderImpl;
@@ -98,7 +97,7 @@ public class BukkitPlatform implements BackendPlatform {
             //not spigot
         }
         if (Bukkit.getPluginManager().isPluginEnabled("PremiumVanish")) {
-            PremiumVanishHook.setInstance(new BukkitPremiumVanishHook());
+            new BukkitPremiumVanishHook().register();
         }
         PingRetriever.tryLoad();
         ComponentConverter.tryLoad(serverVersion);

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
@@ -53,7 +53,7 @@ public class BungeePlatform extends ProxyPlatform {
     public BungeePlatform(@NotNull BungeeTAB plugin) {
         this.plugin = plugin;
         if (ProxyServer.getInstance().getPluginManager().getPlugin("PremiumVanish") != null) {
-            PremiumVanishHook.setInstance(new BungeePremiumVanishHook(this));
+            new BungeePremiumVanishHook(this).register();
         }
     }
 

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeeTabPlayer.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeeTabPlayer.java
@@ -1,9 +1,9 @@
 package me.neznamy.tab.platforms.bungeecord;
 
+import me.neznamy.tab.api.integration.VanishIntegration;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.TabComponent;
-import me.neznamy.tab.shared.hook.PremiumVanishHook;
 import me.neznamy.tab.shared.platform.TabList;
 import me.neznamy.tab.shared.proxy.ProxyTabPlayer;
 import net.md_5.bungee.UserConnection;
@@ -106,7 +106,7 @@ public class BungeeTabPlayer extends ProxyTabPlayer {
 
     @Override
     public boolean isVanished() {
-        if (PremiumVanishHook.getInstance() != null && PremiumVanishHook.getInstance().isVanished(this)) return true;
+        if (VanishIntegration.getHandlers().stream().anyMatch(integration -> integration.isVanished(this))) return true;
         return super.isVanished();
     }
 

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/hook/BungeePremiumVanishHook.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/hook/BungeePremiumVanishHook.java
@@ -1,11 +1,11 @@
 package me.neznamy.tab.platforms.bungeecord.hook;
 
 import de.myzelyam.api.vanish.BungeeVanishAPI;
+import me.neznamy.tab.api.TabPlayer;
 import me.neznamy.tab.platforms.bungeecord.BungeeTabPlayer;
 import me.neznamy.tab.shared.chat.TabComponent;
 import me.neznamy.tab.shared.hook.PremiumVanishHook;
 import me.neznamy.tab.shared.platform.Platform;
-import me.neznamy.tab.shared.platform.TabPlayer;
 import me.neznamy.tab.shared.util.ReflectionUtils;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import org.jetbrains.annotations.NotNull;
@@ -36,13 +36,13 @@ public class BungeePremiumVanishHook extends PremiumVanishHook {
     }
 
     @Override
-    public synchronized boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+    public boolean canSee(TabPlayer viewer, TabPlayer target) {
         //noinspection ConstantValue
         return canSeeEnabled && BungeeVanishAPI.canSee(((BungeeTabPlayer)viewer).getPlayer(), ((BungeeTabPlayer)target).getPlayer());
     }
 
     @Override
-    public boolean isVanished(@NotNull TabPlayer player) {
+    public boolean isVanished(TabPlayer player) {
         try {
             return BungeeVanishAPI.isInvisible(((BungeeTabPlayer)player).getPlayer());
         } catch (IllegalStateException ignored) {

--- a/shared/src/main/java/me/neznamy/tab/shared/hook/PremiumVanishHook.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/hook/PremiumVanishHook.java
@@ -1,40 +1,12 @@
 package me.neznamy.tab.shared.hook;
 
-import lombok.Getter;
-import lombok.Setter;
-import me.neznamy.tab.shared.platform.TabPlayer;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import me.neznamy.tab.api.integration.VanishIntegration;
 
 /**
  * Class for hooking into PremiumVanish to get vanish status of players.
  */
-public abstract class PremiumVanishHook {
-
-    /** Instance of the class, if PremiumVanish is available */
-    @Nullable
-    @Getter
-    @Setter
-    private static PremiumVanishHook instance;
-
-    /**
-     * Returns {@code true} if {@code viewer} can see the {@code target} player,
-     * {@code false} if not.
-     *
-     * @param   viewer
-     *          Viewing player
-     * @param   target
-     *          Player who is being viewed
-     * @return  {@code true} if can see, {@code false} if not.
-     */
-    public abstract boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target);
-
-    /**
-     * Returns {@code true} if player is vanished, {@code false} if not.
-     *
-     * @param   player
-     *          Player to check
-     * @return  {@code true} if player is vanished, {@code false} if not.
-     */
-    public abstract boolean isVanished(@NotNull TabPlayer player);
+public abstract class PremiumVanishHook extends VanishIntegration {
+    public PremiumVanishHook() {
+        super("PremiumVanish");
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
@@ -1,5 +1,6 @@
 package me.neznamy.tab.shared.platform;
 
+import me.neznamy.tab.api.integration.VanishIntegration;
 import me.neznamy.tab.shared.GroupManager;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.TabComponent;
@@ -7,7 +8,6 @@ import me.neznamy.tab.shared.features.PerWorldPlayerListConfiguration;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.redis.RedisSupport;
 import me.neznamy.tab.shared.features.types.TabFeature;
-import me.neznamy.tab.shared.hook.PremiumVanishHook;
 import me.neznamy.tab.shared.placeholders.expansion.TabExpansion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -201,7 +201,7 @@ public interface Platform {
      */
     default boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
         try {
-            if (PremiumVanishHook.getInstance() != null && PremiumVanishHook.getInstance().canSee(viewer, target)) return true;
+            if (VanishIntegration.getHandlers().stream().anyMatch(integration -> !integration.canSee(viewer, target))) return false;
         } catch (ConcurrentModificationException e) {
             // PV error, try again
             return canSee(viewer, target);

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
@@ -90,7 +90,7 @@ public class VelocityPlatform extends ProxyPlatform {
                     "Until then, the following features will not work: scoreboard-teams, belowname-objective, playerlist-objective, scoreboard"));
         }
         if (plugin.getServer().getPluginManager().isLoaded("premiumvanish")) {
-            PremiumVanishHook.setInstance(new VelocityPremiumVanishHook());
+            new VelocityPremiumVanishHook().register();
         }
     }
 

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/hook/VelocityPremiumVanishHook.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/hook/VelocityPremiumVanishHook.java
@@ -1,9 +1,9 @@
 package me.neznamy.tab.platforms.velocity.hook;
 
 import de.myzelyam.api.vanish.VelocityVanishAPI;
+import me.neznamy.tab.api.TabPlayer;
 import me.neznamy.tab.platforms.velocity.VelocityTabPlayer;
 import me.neznamy.tab.shared.hook.PremiumVanishHook;
-import me.neznamy.tab.shared.platform.TabPlayer;
 import org.jetbrains.annotations.NotNull;
 
 /**


### PR DESCRIPTION
This update introduces a new `VanishIntegration` API to enhance support for vanish plugins, such as PremiumVanish, without requiring TAB to directly rely on their APIs. Previously, TAB needed to interact with plugin-specific APIs, making integration more rigid.  

With the new system:  
- Developers can integrate vanish plugins externally without modifying TAB's core code.  
- The existing PremiumVanish integration has been migrated to use the new API within TAB itself. However, the developer of PremiumVanish can adopt the new API to manage the integration independently, allowing TAB to eventually remove the built-in integration.  
- Other vanish plugins can now seamlessly hook into the API to tailor TAB’s behavior according to their needs.  

I tested the new API with my own plugin, [SayanVanish](https://github.com/Syrent/SayanVanish), and it seems to work perfectly fine. However, I couldn't test the API with PremiumVanish, as it is a premium plugin.  

This approach simplifies extensibility and reduces maintenance overhead for vanish plugin integrations.