### PR TITLE
fix: avoid using TAB's internal vanish checks when a registered vanish integration is available

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
@@ -200,13 +200,13 @@ public interface Platform {
      * @return  {@code true} if can see, {@code false} if not.
      */
     default boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
-        try {
-            if (!VanishIntegration.getHandlers().isEmpty()) {
+        if (!VanishIntegration.getHandlers().isEmpty()) {
+            try {
                 return VanishIntegration.getHandlers().stream().allMatch(integration -> integration.canSee(viewer, target));
+            } catch (ConcurrentModificationException e) {
+                // PV error, try again
+                return canSee(viewer, target);
             }
-        } catch (ConcurrentModificationException e) {
-            // PV error, try again
-            return canSee(viewer, target);
         }
         return !target.isVanished() || viewer.hasPermission(TabConstants.Permission.SEE_VANISHED);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
@@ -201,7 +201,9 @@ public interface Platform {
      */
     default boolean canSee(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
         try {
-            if (VanishIntegration.getHandlers().stream().anyMatch(integration -> !integration.canSee(viewer, target))) return false;
+            if (!VanishIntegration.getHandlers().isEmpty()) {
+                return VanishIntegration.getHandlers().stream().allMatch(integration -> integration.canSee(viewer, target));
+            }
         } catch (ConcurrentModificationException e) {
             // PV error, try again
             return canSee(viewer, target);

--- a/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyTabPlayer.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/proxy/ProxyTabPlayer.java
@@ -169,8 +169,11 @@ public abstract class ProxyTabPlayer extends TabPlayer {
 
     @Override
     public boolean isVanished() {
-        for (VanishIntegration i : VanishIntegration.getHandlers()) {
-            if (i.isVanished(this)) return true;
+        if (!VanishIntegration.getHandlers().isEmpty()) {
+            for (VanishIntegration integration : VanishIntegration.getHandlers()) {
+                if (integration.isVanished(this)) return true;
+            }
+            return false;
         }
         return vanished;
     }


### PR DESCRIPTION
This update ensures that TAB does not check the "vanished" meta if a vanish integration is registered. The redundant check was causing issues with the `canSee` functionality in specific scenarios:  

- A player has the "vanished" meta set (i.e., `isVanished` is true).  
- The registered vanish integration correctly returns `true` for `canSee`.  
- Because `canSee` is true inside integration, TAB continues to check the "vanished" meta. Since the meta indicates the player is vanished, TAB incorrectly overrides the integration’s `canSee` result and returns `false`. 

By skipping the "vanished" meta check when a registered vanish integration is present, this fix ensures the `canSee` behavior aligns with the integration’s logic.