### PR TITLE
Fabric now has a getTPS() approximation.

### DIFF
--- a/fabric/src/main/java/me/neznamy/tab/platforms/fabric/FabricPlatform.java
+++ b/fabric/src/main/java/me/neznamy/tab/platforms/fabric/FabricPlatform.java
@@ -177,7 +177,9 @@ public class FabricPlatform implements BackendPlatform {
 
     @Override
     public double getTPS() {
-        return -1; // Not available
+        double mspt = getMSPT();
+        if(mspt < 50.0) { return 20.0; }
+        return Math.round(1000.0/mspt,2);
     }
 
     @Override


### PR DESCRIPTION
Added Fabric TPS approximation, based on mspt.

If the mspt is under 50t (1000ms/20t -> 50ms/t minimum for 20tps), it will be 20tps; otherwise, it would be inversely proportional to time (1000ms/mspt -> tps).
Also, it's rounded in case the double is not reformatted before being displayed in the tab.