### PR TITLE
Expand multi-server support

### DIFF
--- a/build-logic/src/main/kotlin/tab.platform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/tab.platform-conventions.gradle.kts
@@ -11,5 +11,12 @@ tasks {
         relocate("net.kyori.event", "me.neznamy.tab.libs.net.kyori.event")
         relocate("me.neznamy.yamlassist", "me.neznamy.tab.libs.me.neznamy.yamlassist")
         relocate("org.yaml.snakeyaml", "me.neznamy.tab.libs.org.yaml.snakeyaml")
+        relocate("redis.clients.jedis", "me.neznamy.tab.libs.redis.clients.jedis")
+        relocate("com.google.gson", "me.neznamy.tab.libs.com.google.gson")
+        relocate("org.apache.commons.pool2", "me.neznamy.tab.libs.org.apache.commons.pool2")
+        relocate("org.json", "me.neznamy.tab.libs.org.json")
+        relocate("org.slf4j", "me.neznamy.tab.libs.org.slf4j")
+        relocate("com.rabbitmq", "me.neznamy.tab.libs.com.rabbitmq")
+        relocate("com.saicone.delivery4j", "me.neznamy.tab.libs.com.saicone.delivery4j")
     }
 }

--- a/build-logic/src/main/kotlin/tab.platform-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/tab.platform-conventions.gradle.kts
@@ -12,10 +12,8 @@ tasks {
         relocate("me.neznamy.yamlassist", "me.neznamy.tab.libs.me.neznamy.yamlassist")
         relocate("org.yaml.snakeyaml", "me.neznamy.tab.libs.org.yaml.snakeyaml")
         relocate("redis.clients.jedis", "me.neznamy.tab.libs.redis.clients.jedis")
-        relocate("com.google.gson", "me.neznamy.tab.libs.com.google.gson")
         relocate("org.apache.commons.pool2", "me.neznamy.tab.libs.org.apache.commons.pool2")
         relocate("org.json", "me.neznamy.tab.libs.org.json")
-        relocate("org.slf4j", "me.neznamy.tab.libs.org.slf4j")
         relocate("com.rabbitmq", "me.neznamy.tab.libs.com.rabbitmq")
         relocate("com.saicone.delivery4j", "me.neznamy.tab.libs.com.saicone.delivery4j")
     }

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
@@ -16,7 +16,7 @@ import me.neznamy.tab.shared.ProtocolVersion;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.platform.BossBar;
 import me.neznamy.tab.shared.platform.Scoreboard;
 import me.neznamy.tab.shared.platform.TabList;
@@ -70,10 +70,12 @@ public class BungeePlatform extends ProxyPlatform {
 
     @Override
     @Nullable
-    public RedisSupport getRedisSupport() {
-        if (ReflectionUtils.classExists("com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI") &&
-                RedisBungeeAPI.getRedisBungeeApi() != null) {
-            return new BungeeRedisSupport(plugin);
+    public ProxySupport getProxySupport(@NotNull String plugin) {
+        if (plugin.equalsIgnoreCase("RedisBungee")) {
+            if (ReflectionUtils.classExists("com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI") &&
+                    RedisBungeeAPI.getRedisBungeeApi() != null) {
+                return new BungeeRedisSupport(this.plugin);
+            }
         }
         return null;
     }

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/features/BungeeRedisSupport.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/features/BungeeRedisSupport.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import me.neznamy.tab.platforms.bungeecord.BungeeTAB;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
  * RedisBungee implementation for BungeeCord
  */
 @AllArgsConstructor
-public class BungeeRedisSupport extends RedisSupport implements Listener {
+public class BungeeRedisSupport extends ProxySupport implements Listener {
 
     /** Plugin reference for registering listener */
     @NotNull
@@ -30,26 +30,26 @@ public class BungeeRedisSupport extends RedisSupport implements Listener {
      */
     @EventHandler
     public void onMessage(@NotNull PubSubMessageEvent e) {
-        if (!e.getChannel().equals(TabConstants.REDIS_CHANNEL_NAME)) return;
+        if (!e.getChannel().equals(TabConstants.PROXY_CHANNEL_NAME)) return;
         processMessage(e.getMessage());
     }
 
     @Override
     public void register() {
         ProxyServer.getInstance().getPluginManager().registerListener(plugin, this);
-        RedisBungeeAPI.getRedisBungeeApi().registerPubSubChannels(TabConstants.REDIS_CHANNEL_NAME);
+        RedisBungeeAPI.getRedisBungeeApi().registerPubSubChannels(TabConstants.PROXY_CHANNEL_NAME);
     }
 
     @Override
     public void unregister() {
         ProxyServer.getInstance().getPluginManager().unregisterListener(this);
-        RedisBungeeAPI.getRedisBungeeApi().unregisterPubSubChannels(TabConstants.REDIS_CHANNEL_NAME);
+        RedisBungeeAPI.getRedisBungeeApi().unregisterPubSubChannels(TabConstants.PROXY_CHANNEL_NAME);
     }
 
     @Override
     public void sendMessage(@NotNull String message) {
         try {
-            RedisBungeeAPI.getRedisBungeeApi().sendChannelMessage(TabConstants.REDIS_CHANNEL_NAME, message);
+            RedisBungeeAPI.getRedisBungeeApi().sendChannelMessage(TabConstants.PROXY_CHANNEL_NAME, message);
         } catch (Exception e) {
             TAB.getInstance().getErrorManager().redisBungeeMessageSendFail(e);
         }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -21,6 +21,11 @@ dependencies {
     compileOnlyApi("org.geysermc.floodgate:api:2.2.0-SNAPSHOT")
     compileOnlyApi("net.kyori:adventure-api:4.18.0")
     compileOnlyApi("net.kyori:adventure-text-minimessage:4.18.0")
+    implementation("com.saicone.delivery4j:delivery4j:1.1.1")
+    implementation("com.saicone.delivery4j:broker-rabbitmq:1.1.1")
+    implementation("com.saicone.delivery4j:broker-redis:1.1.1")
+    implementation("com.saicone.delivery4j:extension-guava:1.1.1")
+    implementation("org.slf4j:slf4j-nop:1.7.36")
 }
 
 blossom {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -22,10 +22,14 @@ dependencies {
     compileOnlyApi("net.kyori:adventure-api:4.18.0")
     compileOnlyApi("net.kyori:adventure-text-minimessage:4.18.0")
     implementation("com.saicone.delivery4j:delivery4j:1.1.1")
-    implementation("com.saicone.delivery4j:broker-rabbitmq:1.1.1")
-    implementation("com.saicone.delivery4j:broker-redis:1.1.1")
+    implementation("com.saicone.delivery4j:broker-rabbitmq:1.1.1") {
+        exclude("org.slf4j", "slf4j-api")
+    }
+    implementation("com.saicone.delivery4j:broker-redis:1.1.1") {
+        exclude("com.google.code.gson", "gson")
+        exclude("org.slf4j", "slf4j-api")
+    }
     implementation("com.saicone.delivery4j:extension-guava:1.1.1")
-    implementation("org.slf4j:slf4j-nop:1.7.36")
 }
 
 blossom {

--- a/shared/src/main/java/me/neznamy/tab/shared/ErrorManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/ErrorManager.java
@@ -232,8 +232,8 @@ public class ErrorManager {
      * @param   action
      *          Message action
      */
-    public void unknownRedisMessage(@NotNull String action) {
-        printError("RedisSupport received unknown action: \"" + action +
+    public void unknownProxyMessage(@NotNull String action) {
+        printError("ProxySupport received unknown action: \"" + action +
                 "\". Does it come from a feature enabled on another proxy, but not here?",
                 Collections.emptyList(), false, errorLog);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
@@ -16,8 +16,8 @@ import me.neznamy.tab.shared.features.nametags.NameTag;
 import me.neznamy.tab.shared.features.pingspoof.PingSpoof;
 import me.neznamy.tab.shared.features.playerlist.PlayerList;
 import me.neznamy.tab.shared.features.playerlistobjective.YellowNumber;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.features.scoreboard.ScoreboardManagerImpl;
 import me.neznamy.tab.shared.features.sorting.Sorting;
 import me.neznamy.tab.shared.features.types.*;
@@ -403,11 +403,11 @@ public class FeatureManager {
     /**
      * Called when another proxy is reloaded to request all data again.
      */
-    public void onRedisLoadRequest() {
+    public void onProxyLoadRequest() {
         for (TabFeature f : values) {
-            if (!(f instanceof RedisFeature)) continue;
+            if (!(f instanceof ProxyFeature)) continue;
             TimedCaughtTask task = new TimedCaughtTask(TAB.getInstance().getCpu(),
-                    () -> ((RedisFeature) f).onRedisLoadRequest(), f.getFeatureName(), CpuUsageCategory.REDIS_RELOAD);
+                    () -> ((ProxyFeature) f).onProxyLoadRequest(), f.getFeatureName(), CpuUsageCategory.PROXY_RELOAD);
             if (f instanceof CustomThreaded) {
                 ((CustomThreaded) f).getCustomThread().execute(task);
             } else {
@@ -417,16 +417,16 @@ public class FeatureManager {
     }
 
     /**
-     * Handles redis player join and forwards it to all features.
+     * Handles proxy player join and forwards it to all features.
      *
      * @param   connectedPlayer
      *          Player who joined
      */
-    public void onJoin(@NotNull RedisPlayer connectedPlayer) {
+    public void onJoin(@NotNull ProxyPlayer connectedPlayer) {
         for (TabFeature f : values) {
-            if (!(f instanceof RedisFeature)) continue;
+            if (!(f instanceof ProxyFeature)) continue;
             TimedCaughtTask task = new TimedCaughtTask(TAB.getInstance().getCpu(),
-                    () -> ((RedisFeature) f).onJoin(connectedPlayer), f.getFeatureName(), CpuUsageCategory.PLAYER_JOIN);
+                    () -> ((ProxyFeature) f).onJoin(connectedPlayer), f.getFeatureName(), CpuUsageCategory.PLAYER_JOIN);
             if (f instanceof CustomThreaded) {
                 ((CustomThreaded) f).getCustomThread().execute(task);
             } else {
@@ -436,16 +436,16 @@ public class FeatureManager {
     }
 
     /**
-     * Handles redis player server switch and forwards it to all features.
+     * Handles proxy player server switch and forwards it to all features.
      *
      * @param   player
      *          Player who joined
      */
-    public void onServerSwitch(@NotNull RedisPlayer player) {
+    public void onServerSwitch(@NotNull ProxyPlayer player) {
         for (TabFeature f : values) {
-            if (!(f instanceof RedisFeature)) continue;
+            if (!(f instanceof ProxyFeature)) continue;
             TimedCaughtTask task = new TimedCaughtTask(TAB.getInstance().getCpu(),
-                    () -> ((RedisFeature) f).onServerSwitch(player), f.getFeatureName(), CpuUsageCategory.SERVER_SWITCH);
+                    () -> ((ProxyFeature) f).onServerSwitch(player), f.getFeatureName(), CpuUsageCategory.SERVER_SWITCH);
             if (f instanceof CustomThreaded) {
                 ((CustomThreaded) f).getCustomThread().execute(task);
             } else {
@@ -455,16 +455,16 @@ public class FeatureManager {
     }
 
     /**
-     * Handles redis player quit and forwards it to all features.
+     * Handles proxy player quit and forwards it to all features.
      *
      * @param   disconnectedPlayer
      *          Player who left
      */
-    public void onQuit(@NotNull RedisPlayer disconnectedPlayer) {
+    public void onQuit(@NotNull ProxyPlayer disconnectedPlayer) {
         for (TabFeature f : values) {
-            if (!(f instanceof RedisFeature)) continue;
+            if (!(f instanceof ProxyFeature)) continue;
             TimedCaughtTask task = new TimedCaughtTask(TAB.getInstance().getCpu(),
-                    () -> ((RedisFeature) f).onQuit(disconnectedPlayer), f.getFeatureName(), CpuUsageCategory.PLAYER_QUIT);
+                    () -> ((ProxyFeature) f).onQuit(disconnectedPlayer), f.getFeatureName(), CpuUsageCategory.PLAYER_QUIT);
             if (f instanceof CustomThreaded) {
                 ((CustomThreaded) f).getCustomThread().execute(task);
             } else {
@@ -482,11 +482,11 @@ public class FeatureManager {
      * @param   player
      *          Player whose vanish status changed
      */
-    public void onVanishStatusChange(@NotNull RedisPlayer player) {
+    public void onVanishStatusChange(@NotNull ProxyPlayer player) {
         for (TabFeature f : values) {
-            if (!(f instanceof RedisFeature)) continue;
+            if (!(f instanceof ProxyFeature)) continue;
             TimedCaughtTask task = new TimedCaughtTask(TAB.getInstance().getCpu(),
-                    () -> ((RedisFeature) f).onVanishStatusChange(player), f.getFeatureName(), CpuUsageCategory.VANISH_CHANGE);
+                    () -> ((ProxyFeature) f).onVanishStatusChange(player), f.getFeatureName(), CpuUsageCategory.VANISH_CHANGE);
             if (f instanceof CustomThreaded) {
                 ((CustomThreaded) f).getCustomThread().execute(task);
             } else {
@@ -565,9 +565,13 @@ public class FeatureManager {
         FeatureManager featureManager = TAB.getInstance().getFeatureManager();
 
         // Load the feature first, because it will be processed in main thread (to make it run before feature threads)
-        if (config.isEnableRedisHook()) {
-            RedisSupport redis = TAB.getInstance().getPlatform().getRedisSupport();
-            if (redis != null) TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.REDIS_BUNGEE, redis);
+        if (config.isEnableProxySupport()) {
+            String type = config.getConfig().getString("proxy-support.type");
+            if (type.equalsIgnoreCase("PLUGIN")) {
+                String plugin = config.getConfig().getString("proxy-support.plugin.name");
+                ProxySupport proxy = TAB.getInstance().getPlatform().getProxySupport(plugin);
+                if (proxy != null) TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.PROXY_SUPPORT, proxy);
+            }
         }
 
         if (config.isPipelineInjection()) {

--- a/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
@@ -635,7 +635,7 @@ public class FeatureManager {
         }
 
         // Must be loaded after: PlayerList
-        if (config.getGlobalPlayerList() != null && TAB.getInstance().getPlatform().isProxy()) {
+        if (config.getGlobalPlayerList() != null) {
             featureManager.registerFeature(TabConstants.Feature.GLOBAL_PLAYER_LIST, new GlobalPlayerList(config.getGlobalPlayerList()));
         }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/TAB.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/TAB.java
@@ -149,6 +149,17 @@ public class TAB extends TabAPI {
     }
 
     /**
+     * Check if the provided TabList UUID is registered as connected player.
+     *
+     * @param   tabListId
+     *          TabList id of player
+     * @return  true if player is connected, false otherwise.
+     */
+    public boolean isPlayerConnected(UUID tabListId) {
+        return playersByTabListId.containsKey(tabListId);
+    }
+
+    /**
      * Returns player by TabList UUID. This is required due to Velocity
      * as player uuid and TabList uuid do not match there at some circumstances
      *

--- a/shared/src/main/java/me/neznamy/tab/shared/TabConstants.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/TabConstants.java
@@ -20,7 +20,7 @@ public class TabConstants {
     public static final String NO_GROUP = "NONE";
     public static final String DEFAULT_GROUP = "_DEFAULT_";
     public static final String PLUGIN_MESSAGE_CHANNEL_NAME = "tab:bridge-6";
-    public static final String REDIS_CHANNEL_NAME = PLUGIN_NAME;
+    public static final String PROXY_CHANNEL_NAME = PLUGIN_NAME;
     public static final String PIPELINE_HANDLER_NAME = PLUGIN_NAME;
 
     public static final int BSTATS_PLUGIN_ID_BUKKIT = 5304;
@@ -44,7 +44,7 @@ public class TabConstants {
         public static final String WORLD_SWITCH = "World Switch";
         public static final String SERVER_SWITCH = "Server Switch";
         public static final String COMMAND_PREPROCESS = "Command Preprocess";
-        public static final String REDIS_BUNGEE_MESSAGE = "Redis Message processing";
+        public static final String PROXY_MESSAGE = "Proxy Message processing";
 
         public static final String PLUGIN_MESSAGE_DECODE = "Decoding message";
         public static final String PLUGIN_MESSAGE_PROCESS = "Processing message";
@@ -65,7 +65,7 @@ public class TabConstants {
         public static final String BYTE_BUF = "ByteBuf";
         public static final String PACKET_LOGIN = "Login packet";
         public static final String SCOREBOARD_PACKET_CHECK = "Checking for other plugins";
-        public static final String REDIS_RELOAD = "Processing reload from another proxy";
+        public static final String PROXY_RELOAD = "Processing reload from another proxy";
         public static final String GROUP_CHANGE = "Processing group change";
 
         // Placeholders
@@ -148,12 +148,12 @@ public class TabConstants {
         public static final String NAME_TAGS_VISIBILITY = "NameTagVisibility";
         public static final String PLACEHOLDER_MANAGER = "PlaceholderManager";
         public static final String PING_SPOOF = "PingSpoof";
+        public static final String PROXY_SUPPORT = "ProxySupport";
 
         //Bukkit only
         public static final String PER_WORLD_PLAYER_LIST = "PerWorldPlayerList";
 
         //BungeeCord only
-        public static final String REDIS_BUNGEE = "RedisBungee";
         public static final String GLOBAL_PLAYER_LIST = "GlobalPlayerList";
 
         //additional info displayed in cpu command

--- a/shared/src/main/java/me/neznamy/tab/shared/backend/BackendPlatform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/backend/BackendPlatform.java
@@ -7,7 +7,7 @@ import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.hook.LuckPermsHook;
 import me.neznamy.tab.shared.placeholders.UniversalPlaceholderRegistry;
 import me.neznamy.tab.shared.platform.Platform;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.util.PerformanceUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,7 +24,7 @@ public interface BackendPlatform extends Platform {
         return new GroupManager("None", p -> TabConstants.NO_GROUP);
     }
 
-    default RedisSupport getRedisSupport() { return null; }
+    default ProxySupport getProxySupport(@NotNull String plugin) { return null; }
 
     @Override
     default void registerPlaceholders() {

--- a/shared/src/main/java/me/neznamy/tab/shared/config/Converter.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/Converter.java
@@ -503,8 +503,10 @@ public class Converter {
      *          Config file
      */
     public void convert507to508(@NotNull ConfigurationFile config) {
-        config.rename("enable-redisbungee-support", "proxy-support.enabled");
-        config.set("proxy-support.type", "PLUGIN");
-        config.set("proxy-support.plugin.name", "RedisBungee");
+        if (config.rename("enable-redisbungee-support", "proxy-support.enabled")) {
+            TAB.getInstance().getPlatform().logInfo(new TextComponent("Performing configuration conversion from 5.0.7 to 5.0.8", TextColor.YELLOW));
+            config.set("proxy-support.type", "PLUGIN");
+            config.set("proxy-support.plugin.name", "RedisBungee");
+        }
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/config/Converter.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/Converter.java
@@ -494,4 +494,17 @@ public class Converter {
         config.rename("belowname-objective.fancy-display-players", "belowname-objective.fancy-value");
         config.rename("belowname-objective.fancy-display-default", "belowname-objective.fancy-value-default");
     }
+
+    /**
+     * Converts config from 5.0.7 to 5.0.8.
+     * This creates the option proxy-support and remove the old enable-redisbungee-support configuration.
+     *
+     * @param   config
+     *          Config file
+     */
+    public void convert507to508(@NotNull ConfigurationFile config) {
+        config.rename("enable-redisbungee-support", "proxy-support.enabled");
+        config.set("proxy-support.type", "PLUGIN");
+        config.set("proxy-support.plugin.name", "RedisBungee");
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/config/Converter.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/Converter.java
@@ -507,6 +507,9 @@ public class Converter {
             TAB.getInstance().getPlatform().logInfo(new TextComponent("Performing configuration conversion from 5.0.7 to 5.0.8", TextColor.YELLOW));
             config.set("proxy-support.type", "PLUGIN");
             config.set("proxy-support.plugin.name", "RedisBungee");
+            config.set("proxy-support.redis.url", "redis://:password@localhost:6379/0");
+            config.set("proxy-support.rabbitmq.exchange", "plugin");
+            config.set("proxy-support.rabbitmq.url", "amqp://guest:guest@localhost:5672/%2F");
         }
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/config/files/Config.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/files/Config.java
@@ -61,7 +61,7 @@ public class Config {
     private final boolean pipelineInjection = getSecretOption("pipeline-injection", true);
     @NotNull private final String serverName = getSecretOption("server-name", "N/A");
     private final int permissionRefreshInterval = config.getInt("permission-refresh-interval", 1000);
-    private final boolean enableRedisHook = config.getBoolean("enable-redisbungee-support", true);
+    private final boolean enableProxySupport = config.getBoolean("proxy-support.enabled", true);
     private final boolean packetEventsCompensation = config.getBoolean("compensate-for-packetevents-bug", false) && !TAB.getInstance().getPlatform().isSafeFromPacketEventsBug();
 
     /** If enabled, groups are assigned via permissions instead of permission plugin */
@@ -78,6 +78,7 @@ public class Config {
         converter.convert409to410(config);
         converter.convert419to500(config);
         converter.convert501to502(config);
+        converter.convert507to508(config);
 
         conditions = ConditionsSection.fromSection(config.getConfigurationSection("conditions"));
         refresh = PlaceholderRefreshConfiguration.fromSection(config.getConfigurationSection("placeholderapi-refresh-intervals"));

--- a/shared/src/main/java/me/neznamy/tab/shared/features/NickCompatibility.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/NickCompatibility.java
@@ -9,8 +9,8 @@ import me.neznamy.tab.shared.cpu.TimedCaughtTask;
 import me.neznamy.tab.shared.features.belowname.BelowName;
 import me.neznamy.tab.shared.features.nametags.NameTag;
 import me.neznamy.tab.shared.features.playerlistobjective.YellowNumber;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.features.types.EntryAddListener;
 import me.neznamy.tab.shared.features.types.TabFeature;
 import me.neznamy.tab.shared.platform.Scoreboard;
@@ -31,7 +31,7 @@ public class NickCompatibility extends TabFeature implements EntryAddListener {
     @Nullable private final NameTag nameTags = TAB.getInstance().getNameTagManager();
     @Nullable private final BelowName belowname = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.BELOW_NAME);
     @Nullable private final YellowNumber yellownumber = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.YELLOW_NUMBER);
-    @Nullable private final RedisSupport redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
+    @Nullable private final ProxySupport proxy = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PROXY_SUPPORT);
 
     public synchronized void onEntryAdd(TabPlayer packetReceiver, UUID id, String name) {
         TabPlayer packetPlayer = TAB.getInstance().getPlayerByTabListUUID(id);
@@ -47,13 +47,13 @@ public class NickCompatibility extends TabFeature implements EntryAddListener {
             TAB.getInstance().debug("Processing name change of player " + packetPlayer.getName() + " to " + name);
             processNameChange(packetPlayer);
         }
-        if (redis != null) {
-            RedisPlayer redisPlayer = redis.getRedisPlayers().get(id);
-            if (redisPlayer == null) return;
-            if (!redisPlayer.getNickname().equals(name)) {
-                redisPlayer.setNickname(name);
-                TAB.getInstance().debug("Processing name change of redis player " + redisPlayer.getName() + " to " + name);
-                processNameChange(redisPlayer);
+        if (proxy != null) {
+            ProxyPlayer proxyPlayer = proxy.getProxyPlayers().get(id);
+            if (proxyPlayer == null) return;
+            if (!proxyPlayer.getNickname().equals(name)) {
+                proxyPlayer.setNickname(name);
+                TAB.getInstance().debug("Processing name change of proxy player " + proxyPlayer.getName() + " to " + name);
+                processNameChange(proxyPlayer);
             }
         }
     }
@@ -87,7 +87,7 @@ public class NickCompatibility extends TabFeature implements EntryAddListener {
         }, getFeatureName(), CpuUsageCategory.NICK_PLUGIN_COMPATIBILITY));
     }
 
-    private void processNameChange(RedisPlayer player) {
+    private void processNameChange(ProxyPlayer player) {
         CpuManager cpu = TAB.getInstance().getCpu();
         cpu.getProcessingThread().execute(new TimedCaughtTask(cpu, () -> {
             if (nameTags != null) {

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
@@ -307,8 +307,10 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
     public void onJoin(@NotNull ProxyPlayer player) {
         if (TAB.getInstance().getPlatform().isProxy()) return;
         if (player.getBelowNameFancy() == null) return; // This proxy player is not loaded yet
+        // Below name is already being processed by connected player
+        if (TAB.getInstance().isPlayerConnected(player.getUniqueId())) return;
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.belowNameData.disabled.get() || viewer.getUniqueId().equals(player.getUniqueId())) continue;
+            if (viewer.belowNameData.disabled.get()) continue;
             viewer.getScoreboard().setScore(
                     OBJECTIVE_NAME,
                     player.getNickname(),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
@@ -303,22 +303,6 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
         }
     }
 
-    @Override
-    public void onJoin(@NotNull ProxyPlayer player) {
-        if (TAB.getInstance().getPlatform().isProxy()) return;
-        if (player.getBelowNameFancy() == null) return; // This proxy player is not loaded yet
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.belowNameData.disabled.get()) continue;
-            viewer.getScoreboard().setScore(
-                    OBJECTIVE_NAME,
-                    player.getNickname(),
-                    player.getBelowNameNumber(),
-                    null, // Unused by this objective slot
-                    player.getBelowNameFancy()
-            );
-        }
-    }
-
     @NotNull
     @Override
     public String getFeatureName() {

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
@@ -307,8 +307,6 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
     public void onJoin(@NotNull ProxyPlayer player) {
         if (TAB.getInstance().getPlatform().isProxy()) return;
         if (player.getBelowNameFancy() == null) return; // This proxy player is not loaded yet
-        // Below name is already being processed by connected player
-        if (TAB.getInstance().isPlayerConnected(player.getUniqueId())) return;
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
             if (viewer.belowNameData.disabled.get()) continue;
             viewer.getScoreboard().setScore(

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
@@ -308,7 +308,7 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
         if (TAB.getInstance().getPlatform().isProxy()) return;
         if (player.getBelowNameFancy() == null) return; // This proxy player is not loaded yet
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.belowNameData.disabled.get()) continue;
+            if (viewer.belowNameData.disabled.get() || viewer.getUniqueId().equals(player.getUniqueId())) continue;
             viewer.getScoreboard().setScore(
                     OBJECTIVE_NAME,
                     player.getNickname(),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
@@ -292,10 +292,30 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
         onlinePlayers.removePlayer(disconnectedPlayer);
     }
 
+    // ------------------
+    // ProxySupport
+    // ------------------
+
     @Override
     public void onProxyLoadRequest() {
         for (TabPlayer all : onlinePlayers.getPlayers()) {
             proxy.sendMessage(new BelowNameUpdateProxyPlayer(this, all.getTablistId(), getValue(all), all.belowNameData.numberFormat.get()));
+        }
+    }
+
+    @Override
+    public void onJoin(@NotNull ProxyPlayer player) {
+        if (TAB.getInstance().getPlatform().isProxy()) return;
+        if (player.getBelowNameFancy() == null) return; // This proxy player is not loaded yet
+        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+            if (viewer.belowNameData.disabled.get()) continue;
+            viewer.getScoreboard().setScore(
+                    OBJECTIVE_NAME,
+                    player.getNickname(),
+                    player.getBelowNameNumber(),
+                    null, // Unused by this objective slot
+                    player.getBelowNameFancy()
+            );
         }
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowNameUpdateProxyPlayer.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowNameUpdateProxyPlayer.java
@@ -6,20 +6,20 @@ import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.cpu.ThreadExecutor;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
-import me.neznamy.tab.shared.features.redis.message.RedisMessage;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
+import me.neznamy.tab.shared.features.proxy.message.ProxyMessage;
 import me.neznamy.tab.shared.platform.TabPlayer;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 /**
- * Redis message to update belowname data of a player.
+ * Proxy message to update belowname data of a player.
  */
 @RequiredArgsConstructor
 @AllArgsConstructor
-public class BelowNameUpdateRedisPlayer extends RedisMessage {
+public class BelowNameUpdateProxyPlayer extends ProxyMessage {
 
     @NotNull
     private final BelowName feature;
@@ -48,14 +48,14 @@ public class BelowNameUpdateRedisPlayer extends RedisMessage {
     }
 
     @Override
-    public void process(@NotNull RedisSupport redisSupport) {
-        RedisPlayer target = redisSupport.getRedisPlayers().get(playerId);
+    public void process(@NotNull ProxySupport proxySupport) {
+        ProxyPlayer target = proxySupport.getProxyPlayers().get(playerId);
         if (target == null) {
-            TAB.getInstance().getErrorManager().printError("Unable to process Belowname objective update of redis player " + playerId + ", because no such player exists", null);
+            TAB.getInstance().getErrorManager().printError("Unable to process Belowname objective update of proxy player " + playerId + ", because no such player exists", null);
             return;
         }
         if (target.getBelowNameFancy() == null) {
-            TAB.getInstance().debug("Processing belowname objective join of redis player " + target.getName());
+            TAB.getInstance().debug("Processing belowname objective join of proxy player " + target.getName());
         }
         target.setBelowNameNumber(value);
         target.setBelowNameFancy(feature.getCache().get(fancyValue));

--- a/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
@@ -8,8 +8,8 @@ import me.neznamy.chat.component.TabComponent;
 import me.neznamy.tab.shared.cpu.ThreadExecutor;
 import me.neznamy.tab.shared.cpu.TimedCaughtTask;
 import me.neznamy.tab.shared.features.playerlist.PlayerList;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.platform.TabList;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.platform.TabPlayer;
@@ -23,11 +23,11 @@ import org.jetbrains.annotations.Nullable;
  * Feature handler for global PlayerList feature.
  */
 public class GlobalPlayerList extends RefreshableFeature implements JoinListener, QuitListener, VanishListener, GameModeListener,
-        Loadable, UnLoadable, ServerSwitchListener, TabListClearListener, CustomThreaded, RedisFeature {
+        Loadable, UnLoadable, ServerSwitchListener, TabListClearListener, CustomThreaded, ProxyFeature {
 
     @Getter private final ThreadExecutor customThread = new ThreadExecutor("TAB Global PlayerList Thread");
     @Getter private OnlinePlayers onlinePlayers;
-    @Nullable private final RedisSupport redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
+    @Nullable private final ProxySupport proxy = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PROXY_SUPPORT);
     @NotNull private final GlobalPlayerListConfiguration configuration;
     @NotNull  private final Map<String, String> serverToGroupName = new HashMap<>();
     @NotNull private final Map<String, Object> groupNameToGroup = new HashMap<>();
@@ -48,8 +48,8 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
                 for (TabPlayer player : onlinePlayers.getPlayers()) {
                     if (entry.getValue().contains(player.server) && !player.isVanished()) count++;
                 }
-                if (redis != null) {
-                    for (RedisPlayer player : redis.getRedisPlayers().values()) {
+                if (proxy != null) {
+                    for (ProxyPlayer player : proxy.getProxyPlayers().values()) {
                         if (entry.getValue().contains(player.server) && !player.isVanished()) count++;
                     }
                 }
@@ -160,10 +160,10 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
                 connectedPlayer.getTabList().addEntry(getAddInfoData(all, connectedPlayer));
             }
         }
-        if (redis != null) {
-            for (RedisPlayer redis : redis.getRedisPlayers().values()) {
-                if (!redis.server.equals(connectedPlayer.server) && shouldSee(connectedPlayer, redis)) {
-                    connectedPlayer.getTabList().addEntry(getEntry(redis));
+        if (proxy != null) {
+            for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
+                if (!proxied.server.equals(connectedPlayer.server) && shouldSee(connectedPlayer, proxied)) {
+                    connectedPlayer.getTabList().addEntry(getEntry(proxied));
                 }
             }
         }
@@ -205,10 +205,10 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
                 player.getTabList().addEntry(getAddInfoData(all, player));
             }
         }
-        if (redis != null) {
-            for (RedisPlayer redis : redis.getRedisPlayers().values()) {
-                if (!redis.server.equals(player.server) && shouldSee(player, redis)) {
-                    player.getTabList().addEntry(getEntry(redis));
+        if (proxy != null) {
+            for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
+                if (!proxied.server.equals(player.server) && shouldSee(player, proxied)) {
+                    player.getTabList().addEntry(getEntry(proxied));
                 }
             }
         }
@@ -288,23 +288,23 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
         }
     }
 
-    private boolean shouldSee(@NotNull TabPlayer viewer, @NotNull RedisPlayer target) {
+    private boolean shouldSee(@NotNull TabPlayer viewer, @NotNull ProxyPlayer target) {
         if (target.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED)) return false;
         if (viewer.globalPlayerListData.onSpyServer) return true;
         return viewer.globalPlayerListData.serverGroup == target.serverGroup;
     }
 
     @NotNull
-    private TabList.Entry getEntry(@NotNull RedisPlayer player) {
+    private TabList.Entry getEntry(@NotNull ProxyPlayer player) {
         return new TabList.Entry(player.getUniqueId(), player.getNickname(), player.getSkin(), true, 0, 0, player.getTabFormat(), 0, true);
     }
 
     // ------------------
-    // RedisBungee
+    // ProxySupport
     // ------------------
 
     @Override
-    public void onJoin(@NotNull RedisPlayer player) {
+    public void onJoin(@NotNull ProxyPlayer player) {
         player.serverGroup = getServerGroup(player.server);
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
             if (shouldSee(viewer, player) && !viewer.server.equals(player.server)) {
@@ -314,7 +314,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
     }
 
     @Override
-    public void onServerSwitch(@NotNull RedisPlayer player) {
+    public void onServerSwitch(@NotNull ProxyPlayer player) {
         player.serverGroup = getServerGroup(player.server);
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
             if (viewer.server.equals(player.server)) continue;
@@ -327,7 +327,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
     }
 
     @Override
-    public void onQuit(@NotNull RedisPlayer player) {
+    public void onQuit(@NotNull ProxyPlayer player) {
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
             if (!player.server.equals(viewer.server)) {
                 viewer.getTabList().removeEntry(player.getUniqueId());
@@ -336,7 +336,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
     }
 
     @Override
-    public void onVanishStatusChange(@NotNull RedisPlayer player) {
+    public void onVanishStatusChange(@NotNull ProxyPlayer player) {
         if (player.isVanished()) {
             for (TabPlayer all : onlinePlayers.getPlayers()) {
                 if (!shouldSee(all, player)) {

--- a/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
@@ -163,7 +163,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
         if (proxy != null) {
             for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
                 if (!proxied.server.equals(connectedPlayer.server) && shouldSee(connectedPlayer, proxied)) {
-                    connectedPlayer.getTabList().addEntry(getEntry(proxied));
+                    connectedPlayer.getTabList().addEntry(proxied.asEntry());
                 }
             }
         }
@@ -208,7 +208,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
         if (proxy != null) {
             for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
                 if (!proxied.server.equals(player.server) && shouldSee(player, proxied)) {
-                    player.getTabList().addEntry(getEntry(proxied));
+                    player.getTabList().addEntry(proxied.asEntry());
                 }
             }
         }
@@ -294,11 +294,6 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
         return viewer.globalPlayerListData.serverGroup == target.serverGroup;
     }
 
-    @NotNull
-    private TabList.Entry getEntry(@NotNull ProxyPlayer player) {
-        return new TabList.Entry(player.getUniqueId(), player.getNickname(), player.getSkin(), true, 0, 0, player.getTabFormat(), 0, true);
-    }
-
     // ------------------
     // ProxySupport
     // ------------------
@@ -308,7 +303,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
         player.serverGroup = getServerGroup(player.server);
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
             if (shouldSee(viewer, player) && !viewer.server.equals(player.server)) {
-                viewer.getTabList().addEntry(getEntry(player));
+                viewer.getTabList().addEntry(player.asEntry());
             }
         }
     }
@@ -319,7 +314,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
             if (viewer.server.equals(player.server)) continue;
             if (shouldSee(viewer, player)) {
-                viewer.getTabList().addEntry(getEntry(player));
+                viewer.getTabList().addEntry(player.asEntry());
             } else {
                 viewer.getTabList().removeEntry(player.getUniqueId());
             }
@@ -346,7 +341,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
         } else {
             for (TabPlayer viewer : onlinePlayers.getPlayers()) {
                 if (shouldSee(viewer, player)) {
-                    viewer.getTabList().addEntry(getEntry(player));
+                    viewer.getTabList().addEntry(player.asEntry());
                 }
             }
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
@@ -291,6 +291,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
     private boolean shouldSee(@NotNull TabPlayer viewer, @NotNull ProxyPlayer target) {
         if (target.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED)) return false;
         if (viewer.globalPlayerListData.onSpyServer) return true;
+        if (viewer.getUniqueId().equals(target.getUniqueId())) return false;
         return viewer.globalPlayerListData.serverGroup == target.serverGroup;
     }
 
@@ -324,7 +325,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
     @Override
     public void onQuit(@NotNull ProxyPlayer player) {
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-            if (!player.server.equals(viewer.server)) {
+            if (!player.server.equals(viewer.server) && !viewer.getUniqueId().equals(player.getUniqueId())) {
                 viewer.getTabList().removeEntry(player.getUniqueId());
             }
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/globalplayerlist/GlobalPlayerList.java
@@ -290,8 +290,9 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
 
     private boolean shouldSee(@NotNull TabPlayer viewer, @NotNull ProxyPlayer target) {
         if (target.isVanished() && !viewer.hasPermission(TabConstants.Permission.SEE_VANISHED)) return false;
+        // Do not show duplicate player that will be removed in a sec
+        if (TAB.getInstance().isPlayerConnected(target.getUniqueId())) return false;
         if (viewer.globalPlayerListData.onSpyServer) return true;
-        if (viewer.getUniqueId().equals(target.getUniqueId())) return false;
         return viewer.globalPlayerListData.serverGroup == target.serverGroup;
     }
 
@@ -325,7 +326,7 @@ public class GlobalPlayerList extends RefreshableFeature implements JoinListener
     @Override
     public void onQuit(@NotNull ProxyPlayer player) {
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-            if (!player.server.equals(viewer.server) && !viewer.getUniqueId().equals(player.getUniqueId())) {
+            if (!player.server.equals(viewer.server)) {
                 viewer.getTabList().removeEntry(player.getUniqueId());
             }
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
@@ -415,26 +415,6 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
     }
 
     @Override
-    public void onJoin(@NotNull ProxyPlayer player) {
-        if (TAB.getInstance().getPlatform().isProxy()) return;
-        if (player.getTagPrefix() == null) return; // This proxy player is not loaded yet
-        for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-            if (viewer.getUniqueId().equals(player.getUniqueId())) continue;
-            TabComponent prefix = cache.get(player.getTagPrefix());
-            viewer.getScoreboard().registerTeam(
-                    player.getTeamName(),
-                    prefix,
-                    cache.get(player.getTagSuffix()),
-                    player.getNameVisibility(),
-                    CollisionRule.ALWAYS,
-                    Collections.singletonList(player.getNickname()),
-                    2,
-                    prefix.getLastColor()
-            );
-        }
-    }
-
-    @Override
     public void onQuit(@NotNull ProxyPlayer player) {
         if (player.getTeamName() == null) {
             TAB.getInstance().getErrorManager().printError("Unable to unregister team of proxy player " + player.getName() + " on quit, because team is null", null);
@@ -797,6 +777,7 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
             TabComponent prefixComponent = cache.get(prefix);
             if (!newTeamName.equals(oldTeamName)) {
                 for (TabPlayer viewer : onlinePlayers.getPlayers()) {
+                    if (viewer.getUniqueId().equals(target.getUniqueId())) continue;
                     if (oldTeamName != null) viewer.getScoreboard().unregisterTeam(oldTeamName);
                     viewer.getScoreboard().registerTeam(
                             newTeamName,

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
@@ -421,7 +421,6 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
             return;
         }
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-            if (viewer.getUniqueId().equals(player.getUniqueId())) continue;
             ((SafeScoreboard<?>)viewer.getScoreboard()).unregisterTeamSafe(player.getTeamName());
         }
     }
@@ -768,6 +767,11 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
             if (target.getTeamName() == null) {
                 TAB.getInstance().debug("Processing nametag join of proxy player " + target.getName());
             }
+            // Nametag is already being processed by connected player
+            if (TAB.getInstance().isPlayerConnected(target.getUniqueId())) {
+                TAB.getInstance().debug("The player " + target.getName() + " is already connected");
+                return;
+            }
             String oldTeamName = target.getTeamName();
             String newTeamName = checkTeamName(target, teamName.substring(0, teamName.length()-1));
             target.setTeamName(newTeamName);
@@ -777,7 +781,6 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
             TabComponent prefixComponent = cache.get(prefix);
             if (!newTeamName.equals(oldTeamName)) {
                 for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-                    if (viewer.getUniqueId().equals(target.getUniqueId())) continue;
                     if (oldTeamName != null) viewer.getScoreboard().unregisterTeam(oldTeamName);
                     viewer.getScoreboard().registerTeam(
                             newTeamName,

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
@@ -397,6 +397,10 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
         }, getFeatureName(), "Updating team name"));
     }
 
+    // ------------------
+    // ProxySupport
+    // ------------------
+
     @Override
     public void onProxyLoadRequest() {
         for (TabPlayer all : onlinePlayers.getPlayers()) {
@@ -407,6 +411,25 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
                     all.teamData.suffix.get(),
                     getTeamVisibility(all, all) ? NameVisibility.ALWAYS : NameVisibility.NEVER
             ));
+        }
+    }
+
+    @Override
+    public void onJoin(@NotNull ProxyPlayer player) {
+        if (TAB.getInstance().getPlatform().isProxy()) return;
+        if (player.getTagPrefix() == null) return; // This proxy player is not loaded yet
+        for (TabPlayer viewer : onlinePlayers.getPlayers()) {
+            TabComponent prefix = cache.get(player.getTagPrefix());
+            viewer.getScoreboard().registerTeam(
+                    player.getTeamName(),
+                    prefix,
+                    cache.get(player.getTagSuffix()),
+                    player.getNameVisibility(),
+                    CollisionRule.ALWAYS,
+                    Collections.singletonList(player.getNickname()),
+                    2,
+                    prefix.getLastColor()
+            );
         }
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
@@ -419,6 +419,7 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
         if (TAB.getInstance().getPlatform().isProxy()) return;
         if (player.getTagPrefix() == null) return; // This proxy player is not loaded yet
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
+            if (viewer.getUniqueId().equals(player.getUniqueId())) continue;
             TabComponent prefix = cache.get(player.getTagPrefix());
             viewer.getScoreboard().registerTeam(
                     player.getTeamName(),
@@ -440,6 +441,7 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
             return;
         }
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
+            if (viewer.getUniqueId().equals(player.getUniqueId())) continue;
             ((SafeScoreboard<?>)viewer.getScoreboard()).unregisterTeamSafe(player.getTeamName());
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
@@ -278,11 +278,7 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
             }
             if (proxy != null) {
                 for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
-                    if (TAB.getInstance().getPlatform().isProxy()) {
-                        connectedPlayer.getTabList().updateDisplayName(proxied.getUniqueId(), proxied.getTabFormat());
-                    } else {
-                        connectedPlayer.getTabList().addEntry(proxied.asEntry());
-                    }
+                    connectedPlayer.getTabList().updateDisplayName(proxied.getUniqueId(), proxied.getTabFormat());
                 }
             }
         };
@@ -386,24 +382,6 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
     public void onProxyLoadRequest() {
         for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
             proxy.sendMessage(new UpdateProxyPlayer(all.getTablistId(), all.tablistData.prefix.get() + all.tablistData.name.get() + all.tablistData.suffix.get()));
-        }
-    }
-
-    @Override
-    public void onJoin(@NotNull ProxyPlayer player) {
-        if (TAB.getInstance().getPlatform().isProxy()) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.getVersion().getMinorVersion() < 8 || viewer.getUniqueId().equals(player.getUniqueId())) continue;
-            viewer.getTabList().addEntry(player.asEntry());
-        }
-    }
-
-    @Override
-    public void onQuit(@NotNull ProxyPlayer player) {
-        if (TAB.getInstance().getPlatform().isProxy()) return;
-        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.getVersion().getMinorVersion() < 8 || viewer.getUniqueId().equals(player.getUniqueId())) continue;
-            viewer.getTabList().removeEntry(player.getUniqueId());
         }
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
@@ -393,7 +393,7 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
     public void onJoin(@NotNull ProxyPlayer player) {
         if (TAB.getInstance().getPlatform().isProxy()) return;
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.getVersion().getMinorVersion() < 8) return;
+            if (viewer.getVersion().getMinorVersion() < 8 || viewer.getUniqueId().equals(player.getUniqueId())) continue;
             viewer.getTabList().addEntry(player.asEntry());
         }
     }
@@ -402,7 +402,7 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
     public void onQuit(@NotNull ProxyPlayer player) {
         if (TAB.getInstance().getPlatform().isProxy()) return;
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.getVersion().getMinorVersion() < 8) return;
+            if (viewer.getVersion().getMinorVersion() < 8 || viewer.getUniqueId().equals(player.getUniqueId())) continue;
             viewer.getTabList().removeEntry(player.getUniqueId());
         }
     }
@@ -411,7 +411,7 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
     public void onVanishStatusChange(@NotNull ProxyPlayer player) {
         if (player.isVanished()) return;
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.getVersion().getMinorVersion() < 8) continue;
+            if (viewer.getVersion().getMinorVersion() < 8 || viewer.getUniqueId().equals(player.getUniqueId())) continue;
             viewer.getTabList().updateDisplayName(player.getUniqueId(), player.getTabFormat());
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
@@ -389,7 +389,7 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
     public void onVanishStatusChange(@NotNull ProxyPlayer player) {
         if (player.isVanished()) return;
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
-            if (viewer.getVersion().getMinorVersion() < 8 || viewer.getUniqueId().equals(player.getUniqueId())) continue;
+            if (viewer.getVersion().getMinorVersion() < 8) continue;
             viewer.getTabList().updateDisplayName(player.getUniqueId(), player.getTabFormat());
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
@@ -278,7 +278,11 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
             }
             if (proxy != null) {
                 for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
-                    connectedPlayer.getTabList().updateDisplayName(proxied.getUniqueId(), proxied.getTabFormat());
+                    if (TAB.getInstance().getPlatform().isProxy()) {
+                        connectedPlayer.getTabList().updateDisplayName(proxied.getUniqueId(), proxied.getTabFormat());
+                    } else {
+                        connectedPlayer.getTabList().addEntry(proxied.asEntry());
+                    }
                 }
             }
         };
@@ -374,10 +378,32 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
         return ((TabPlayer)player).tablistData.suffix.getOriginalRawValue();
     }
 
+    // ------------------
+    // ProxySupport
+    // ------------------
+
     @Override
     public void onProxyLoadRequest() {
         for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
             proxy.sendMessage(new UpdateProxyPlayer(all.getTablistId(), all.tablistData.prefix.get() + all.tablistData.name.get() + all.tablistData.suffix.get()));
+        }
+    }
+
+    @Override
+    public void onJoin(@NotNull ProxyPlayer player) {
+        if (TAB.getInstance().getPlatform().isProxy()) return;
+        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+            if (viewer.getVersion().getMinorVersion() < 8) return;
+            viewer.getTabList().addEntry(player.asEntry());
+        }
+    }
+
+    @Override
+    public void onQuit(@NotNull ProxyPlayer player) {
+        if (TAB.getInstance().getPlatform().isProxy()) return;
+        for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
+            if (viewer.getVersion().getMinorVersion() < 8) return;
+            viewer.getTabList().removeEntry(player.getUniqueId());
         }
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlist/PlayerList.java
@@ -15,9 +15,9 @@ import me.neznamy.chat.component.SimpleTextComponent;
 import me.neznamy.chat.component.TabComponent;
 import me.neznamy.tab.shared.cpu.TimedCaughtTask;
 import me.neznamy.tab.shared.features.layout.PlayerSlot;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
-import me.neznamy.tab.shared.features.redis.message.RedisMessage;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
+import me.neznamy.tab.shared.features.proxy.message.ProxyMessage;
 import me.neznamy.tab.shared.features.types.*;
 import me.neznamy.tab.shared.placeholders.conditions.Condition;
 import me.neznamy.tab.shared.platform.TabPlayer;
@@ -34,11 +34,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 @Getter
 public class PlayerList extends RefreshableFeature implements TabListFormatManager, JoinListener, Loadable,
-        UnLoadable, WorldSwitchListener, ServerSwitchListener, VanishListener, RedisFeature, GroupListener {
+        UnLoadable, WorldSwitchListener, ServerSwitchListener, VanishListener, ProxyFeature, GroupListener {
 
     @NotNull private final StringToComponentCache cache = new StringToComponentCache("Tablist name formatting", 1000);
     @NotNull private final TablistFormattingConfiguration configuration;
-    @Nullable private final RedisSupport redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
+    @Nullable private final ProxySupport proxy = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PROXY_SUPPORT);
     @NotNull private final DisableChecker disableChecker;
 
     /**
@@ -59,8 +59,8 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
                     }, getFeatureName(), CpuUsageCategory.ANTI_OVERRIDE_TABLIST_PERIODIC), 500
             );
         }
-        if (redis != null) {
-            redis.registerMessage("tabformat", UpdateRedisPlayer.class, UpdateRedisPlayer::new);
+        if (proxy != null) {
+            proxy.registerMessage("tabformat", UpdateProxyPlayer.class, UpdateProxyPlayer::new);
         }
     }
 
@@ -130,7 +130,7 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
             viewer.getTabList().updateDisplayName(tablistId, format ? getTabFormat(player, viewer) :
                     tablistId.getMostSignificantBits() == 0 ? new SimpleTextComponent(player.getName()) : null);
         }
-        if (redis != null) redis.sendMessage(new UpdateRedisPlayer(player.getUniqueId(), player.tablistData.prefix.get() +
+        if (proxy != null) proxy.sendMessage(new UpdateProxyPlayer(player.getUniqueId(), player.tablistData.prefix.get() +
                 player.tablistData.name.get() + player.tablistData.suffix.get()));
     }
 
@@ -162,7 +162,7 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
             if (disableChecker.isDisableConditionMet(all)) {
                 all.tablistData.disabled.set(true);
             } else {
-                if (redis != null) redis.sendMessage(new UpdateRedisPlayer(all.getUniqueId(),
+                if (proxy != null) proxy.sendMessage(new UpdateProxyPlayer(all.getUniqueId(),
                         all.tablistData.prefix.get() + all.tablistData.name.get() + all.tablistData.suffix.get()));
             }
         }
@@ -203,9 +203,9 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
                 )
                     all.getTabList().updateDisplayName(getTablistUUID(p, all), getTabFormat(p, all));
             }
-            if (redis != null) {
-                for (RedisPlayer redis : redis.getRedisPlayers().values()) {
-                    p.getTabList().updateDisplayName(redis.getUniqueId(), redis.getTabFormat());
+            if (proxy != null) {
+                for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
+                    p.getTabList().updateDisplayName(proxied.getUniqueId(), proxied.getTabFormat());
                 }
             }
         }, getFeatureName(), CpuUsageCategory.PLAYER_JOIN), 300);
@@ -276,9 +276,9 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
                 if (all.tablistData.disabled.get()) continue;
                 connectedPlayer.getTabList().updateDisplayName(getTablistUUID(all, connectedPlayer), getTabFormat(all, connectedPlayer));
             }
-            if (redis != null) {
-                for (RedisPlayer redis : redis.getRedisPlayers().values()) {
-                    connectedPlayer.getTabList().updateDisplayName(redis.getUniqueId(), redis.getTabFormat());
+            if (proxy != null) {
+                for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
+                    connectedPlayer.getTabList().updateDisplayName(proxied.getUniqueId(), proxied.getTabFormat());
                 }
             }
         };
@@ -375,14 +375,14 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
     }
 
     @Override
-    public void onRedisLoadRequest() {
+    public void onProxyLoadRequest() {
         for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
-            redis.sendMessage(new UpdateRedisPlayer(all.getTablistId(), all.tablistData.prefix.get() + all.tablistData.name.get() + all.tablistData.suffix.get()));
+            proxy.sendMessage(new UpdateProxyPlayer(all.getTablistId(), all.tablistData.prefix.get() + all.tablistData.name.get() + all.tablistData.suffix.get()));
         }
     }
 
     @Override
-    public void onVanishStatusChange(@NotNull RedisPlayer player) {
+    public void onVanishStatusChange(@NotNull ProxyPlayer player) {
         if (player.isVanished()) return;
         for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {
             if (viewer.getVersion().getMinorVersion() < 8) continue;
@@ -415,11 +415,11 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
     }
 
     /**
-     * Redis message to update tablist format of a player.
+     * Proxy message to update tablist format of a player.
      */
     @NoArgsConstructor
     @AllArgsConstructor
-    private class UpdateRedisPlayer extends RedisMessage {
+    private class UpdateProxyPlayer extends ProxyMessage {
 
         private UUID playerId;
         private String format;
@@ -437,14 +437,14 @@ public class PlayerList extends RefreshableFeature implements TabListFormatManag
         }
 
         @Override
-        public void process(@NotNull RedisSupport redisSupport) {
-            RedisPlayer target = redisSupport.getRedisPlayers().get(playerId);
+        public void process(@NotNull ProxySupport proxySupport) {
+            ProxyPlayer target = proxySupport.getProxyPlayers().get(playerId);
             if (target == null) {
-                TAB.getInstance().getErrorManager().printError("Unable to process tablist format update of redis player " + playerId + ", because no such player exists", null);
+                TAB.getInstance().getErrorManager().printError("Unable to process tablist format update of proxy player " + playerId + ", because no such player exists", null);
                 return;
             }
             if (target.getTabFormat() == null) {
-                TAB.getInstance().debug("Processing tablist formatting join of redis player " + target.getName());
+                TAB.getInstance().debug("Processing tablist formatting join of proxy player " + target.getName());
             }
             target.setTabFormat(cache.get(format));
             for (TabPlayer viewer : TAB.getInstance().getOnlinePlayers()) {

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
@@ -326,10 +326,15 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
             if (target.getPlayerlistFancy() == null) {
                 TAB.getInstance().debug("Processing playerlist objective join of proxy player " + target.getName());
             }
+            // Yellow number is already being processed by connected player
+            if (TAB.getInstance().isPlayerConnected(target.getUniqueId())) {
+                TAB.getInstance().debug("The player " + target.getName() + " is already connected");
+                return;
+            }
             target.setPlayerlistNumber(value);
             target.setPlayerlistFancy(cache.get(fancyValue));
             for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-                if (viewer.playerlistObjectiveData.disabled.get() || viewer.getUniqueId().equals(target.getUniqueId())) continue;
+                if (viewer.playerlistObjectiveData.disabled.get()) continue;
                 viewer.getScoreboard().setScore(
                         OBJECTIVE_NAME,
                         target.getNickname(),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
@@ -254,10 +254,30 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         onlinePlayers.removePlayer(disconnectedPlayer);
     }
 
+    // ------------------
+    // ProxySupport
+    // ------------------
+
     @Override
     public void onProxyLoadRequest() {
         for (TabPlayer all : onlinePlayers.getPlayers()) {
             proxy.sendMessage(new UpdateProxyPlayer(all.getTablistId(), getValueNumber(all), all.playerlistObjectiveData.valueModern.get()));
+        }
+    }
+
+    @Override
+    public void onJoin(@NotNull ProxyPlayer player) {
+        if (TAB.getInstance().getPlatform().isProxy()) return;
+        if (player.getPlayerlistFancy() == null) return; // This proxy player is not loaded yet
+        for (TabPlayer viewer : onlinePlayers.getPlayers()) {
+            if (viewer.playerlistObjectiveData.disabled.get()) continue;
+            viewer.getScoreboard().setScore(
+                    OBJECTIVE_NAME,
+                    player.getNickname(),
+                    player.getPlayerlistNumber(),
+                    null, // Unused by this objective slot
+                    player.getPlayerlistFancy()
+            );
         }
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
@@ -12,9 +12,9 @@ import me.neznamy.chat.component.SimpleTextComponent;
 import me.neznamy.chat.component.TabComponent;
 import me.neznamy.tab.shared.cpu.ThreadExecutor;
 import me.neznamy.tab.shared.cpu.TimedCaughtTask;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
-import me.neznamy.tab.shared.features.redis.message.RedisMessage;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
+import me.neznamy.tab.shared.features.proxy.message.ProxyMessage;
 import me.neznamy.tab.shared.features.types.*;
 import me.neznamy.tab.shared.placeholders.conditions.Condition;
 import me.neznamy.tab.shared.platform.Scoreboard;
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * PLAYER_LIST display slot (in tablist).
  */
 public class YellowNumber extends RefreshableFeature implements JoinListener, QuitListener, Loadable,
-        CustomThreaded, RedisFeature {
+        CustomThreaded, ProxyFeature {
 
     /** Objective name used by this feature */
     public static final String OBJECTIVE_NAME = "TAB-PlayerList";
@@ -56,7 +56,7 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
     private final DisableChecker disableChecker;
 
     @Nullable
-    private final RedisSupport redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
+    private final ProxySupport proxy = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PROXY_SUPPORT);
 
     /**
      * Constructs new instance and registers disable condition checker to feature manager.
@@ -68,8 +68,8 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         this.configuration = configuration;
         disableChecker = new DisableChecker(this, Condition.getCondition(configuration.getDisableCondition()), this::onDisableConditionChange, p -> p.playerlistObjectiveData.disabled);
         TAB.getInstance().getFeatureManager().registerFeature(TabConstants.Feature.YELLOW_NUMBER + "-Condition", disableChecker);
-        if (redis != null) {
-            redis.registerMessage("yellow-number", UpdateRedisPlayer.class, UpdateRedisPlayer::new);
+        if (proxy != null) {
+            proxy.registerMessage("yellow-number", UpdateProxyPlayer.class, UpdateProxyPlayer::new);
         }
     }
 
@@ -112,8 +112,8 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
                 register(loaded);
             }
             values.put(loaded, getValueNumber(loaded));
-            if (redis != null) {
-                redis.sendMessage(new UpdateRedisPlayer(loaded.getTablistId(), values.get(loaded), loaded.playerlistObjectiveData.valueModern.get()));
+            if (proxy != null) {
+                proxy.sendMessage(new UpdateProxyPlayer(loaded.getTablistId(), values.get(loaded), loaded.playerlistObjectiveData.valueModern.get()));
             }
         }
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
@@ -142,17 +142,17 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
                 setScore(connectedPlayer, all, getValueNumber(all), all.playerlistObjectiveData.valueModern.getFormat(connectedPlayer));
             }
         }
-        if (redis != null) {
-            redis.sendMessage(new UpdateRedisPlayer(connectedPlayer.getTablistId(), getValueNumber(connectedPlayer), connectedPlayer.playerlistObjectiveData.valueModern.get()));
+        if (proxy != null) {
+            proxy.sendMessage(new UpdateProxyPlayer(connectedPlayer.getTablistId(), getValueNumber(connectedPlayer), connectedPlayer.playerlistObjectiveData.valueModern.get()));
             if (connectedPlayer.playerlistObjectiveData.disabled.get()) return;
-            for (RedisPlayer redis : redis.getRedisPlayers().values()) {
-                if (redis.getPlayerlistFancy() == null) continue; // This redis player is not loaded yet
+            for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
+                if (proxied.getPlayerlistFancy() == null) continue; // This proxy player is not loaded yet
                 connectedPlayer.getScoreboard().setScore(
                         OBJECTIVE_NAME,
-                        redis.getNickname(),
-                        redis.getPlayerlistNumber(),
+                        proxied.getNickname(),
+                        proxied.getPlayerlistNumber(),
                         null, // Unused by this objective slot
-                        redis.getPlayerlistFancy()
+                        proxied.getPlayerlistFancy()
                 );
             }
         }
@@ -174,16 +174,16 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
             for (TabPlayer all : onlinePlayers.getPlayers()) {
                 setScore(p, all, getValueNumber(all), all.playerlistObjectiveData.valueModern.getFormat(p));
             }
-            if (redis != null) {
-                redis.sendMessage(new UpdateRedisPlayer(p.getTablistId(), getValueNumber(p), p.playerlistObjectiveData.valueModern.get()));
-                for (RedisPlayer redis : redis.getRedisPlayers().values()) {
-                    if (redis.getPlayerlistFancy() == null) continue; // This redis player is not loaded yet
+            if (proxy != null) {
+                proxy.sendMessage(new UpdateProxyPlayer(p.getTablistId(), getValueNumber(p), p.playerlistObjectiveData.valueModern.get()));
+                for (ProxyPlayer proxied : proxy.getProxyPlayers().values()) {
+                    if (proxied.getPlayerlistFancy() == null) continue; // This proxy player is not loaded yet
                     p.getScoreboard().setScore(
                             OBJECTIVE_NAME,
-                            redis.getNickname(),
-                            redis.getPlayerlistNumber(),
+                            proxied.getNickname(),
+                            proxied.getPlayerlistNumber(),
                             null, // Unused by this objective slot
-                            redis.getPlayerlistFancy()
+                            proxied.getPlayerlistFancy()
                     );
                 }
             }
@@ -204,7 +204,7 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
             setScore(viewer, refreshed, value, refreshed.playerlistObjectiveData.valueModern.getFormat(viewer));
         }
-        if (redis != null) redis.sendMessage(new UpdateRedisPlayer(refreshed.getTablistId(), value, refreshed.playerlistObjectiveData.valueModern.get()));
+        if (proxy != null) proxy.sendMessage(new UpdateProxyPlayer(refreshed.getTablistId(), value, refreshed.playerlistObjectiveData.valueModern.get()));
     }
 
     private void register(@NotNull TabPlayer player) {
@@ -255,9 +255,9 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
     }
 
     @Override
-    public void onRedisLoadRequest() {
+    public void onProxyLoadRequest() {
         for (TabPlayer all : onlinePlayers.getPlayers()) {
-            redis.sendMessage(new UpdateRedisPlayer(all.getTablistId(), getValueNumber(all), all.playerlistObjectiveData.valueModern.get()));
+            proxy.sendMessage(new UpdateProxyPlayer(all.getTablistId(), getValueNumber(all), all.playerlistObjectiveData.valueModern.get()));
         }
     }
 
@@ -283,11 +283,11 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
     }
 
     /**
-     * Redis message to update playerlist objective data of a player.
+     * Proxy message to update playerlist objective data of a player.
      */
     @NoArgsConstructor
     @AllArgsConstructor
-    private class UpdateRedisPlayer extends RedisMessage {
+    private class UpdateProxyPlayer extends ProxyMessage {
 
         private UUID playerId;
         private int value;
@@ -313,14 +313,14 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         }
 
         @Override
-        public void process(@NotNull RedisSupport redisSupport) {
-            RedisPlayer target = redisSupport.getRedisPlayers().get(playerId);
+        public void process(@NotNull ProxySupport proxySupport) {
+            ProxyPlayer target = proxySupport.getProxyPlayers().get(playerId);
             if (target == null) {
-                TAB.getInstance().getErrorManager().printError("Unable to process Playerlist objective update of redis player " + playerId + ", because no such player exists", null);
+                TAB.getInstance().getErrorManager().printError("Unable to process Playerlist objective update of proxy player " + playerId + ", because no such player exists", null);
                 return;
             }
             if (target.getPlayerlistFancy() == null) {
-                TAB.getInstance().debug("Processing playerlist objective join of redis player " + target.getName());
+                TAB.getInstance().debug("Processing playerlist objective join of proxy player " + target.getName());
             }
             target.setPlayerlistNumber(value);
             target.setPlayerlistFancy(cache.get(fancyValue));

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
@@ -265,22 +265,6 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         }
     }
 
-    @Override
-    public void onJoin(@NotNull ProxyPlayer player) {
-        if (TAB.getInstance().getPlatform().isProxy()) return;
-        if (player.getPlayerlistFancy() == null) return; // This proxy player is not loaded yet
-        for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-            if (viewer.playerlistObjectiveData.disabled.get() || viewer.getUniqueId().equals(player.getUniqueId())) continue;
-            viewer.getScoreboard().setScore(
-                    OBJECTIVE_NAME,
-                    player.getNickname(),
-                    player.getPlayerlistNumber(),
-                    null, // Unused by this objective slot
-                    player.getPlayerlistFancy()
-            );
-        }
-    }
-
     @NotNull
     @Override
     public String getFeatureName() {
@@ -345,7 +329,7 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
             target.setPlayerlistNumber(value);
             target.setPlayerlistFancy(cache.get(fancyValue));
             for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-                if (viewer.playerlistObjectiveData.disabled.get()) continue;
+                if (viewer.playerlistObjectiveData.disabled.get() || viewer.getUniqueId().equals(target.getUniqueId())) continue;
                 viewer.getScoreboard().setScore(
                         OBJECTIVE_NAME,
                         target.getNickname(),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
@@ -270,7 +270,7 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         if (TAB.getInstance().getPlatform().isProxy()) return;
         if (player.getPlayerlistFancy() == null) return; // This proxy player is not loaded yet
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
-            if (viewer.playerlistObjectiveData.disabled.get()) continue;
+            if (viewer.playerlistObjectiveData.disabled.get() || viewer.getUniqueId().equals(player.getUniqueId())) continue;
             viewer.getScoreboard().setScore(
                     OBJECTIVE_NAME,
                     player.getNickname(),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/ProxyMessengerSupport.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/ProxyMessengerSupport.java
@@ -2,19 +2,17 @@ package me.neznamy.tab.shared.features.proxy;
 
 import com.saicone.delivery4j.AbstractMessenger;
 import com.saicone.delivery4j.Broker;
+import lombok.RequiredArgsConstructor;
 import me.neznamy.tab.shared.TabConstants;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Supplier;
 
+@RequiredArgsConstructor
 public class ProxyMessengerSupport extends ProxySupport {
 
     private final Supplier<Broker> brokerSupplier;
     private AbstractMessenger messenger;
-
-    public ProxyMessengerSupport(Supplier<Broker> brokerSupplier) {
-        this.brokerSupplier = brokerSupplier;
-    }
 
     @Override
     public void sendMessage(@NotNull String message) {

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/ProxyMessengerSupport.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/ProxyMessengerSupport.java
@@ -1,0 +1,43 @@
+package me.neznamy.tab.shared.features.proxy;
+
+import com.saicone.delivery4j.AbstractMessenger;
+import com.saicone.delivery4j.Broker;
+import me.neznamy.tab.shared.TabConstants;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Supplier;
+
+public class ProxyMessengerSupport extends ProxySupport {
+
+    private final Supplier<Broker> brokerSupplier;
+    private AbstractMessenger messenger;
+
+    public ProxyMessengerSupport(Supplier<Broker> brokerSupplier) {
+        this.brokerSupplier = brokerSupplier;
+    }
+
+    @Override
+    public void sendMessage(@NotNull String message) {
+        messenger.send(TabConstants.PROXY_CHANNEL_NAME, message);
+    }
+
+    @Override
+    public void register() {
+        messenger = new AbstractMessenger() {
+            @Override
+            protected @NotNull Broker loadBroker() {
+                return brokerSupplier.get();
+            }
+        };
+        messenger.subscribe(TabConstants.PROXY_CHANNEL_NAME).consume((channel, lines) -> {
+            processMessage(lines[0]);
+        }).cache(true);
+        messenger.start();
+    }
+
+    @Override
+    public void unregister() {
+        messenger.close();
+        messenger.clear();
+    }
+}

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/ProxyPlayer.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/ProxyPlayer.java
@@ -95,4 +95,9 @@ public class ProxyPlayer {
         this.vanished = vanished;
         this.staff = staff;
     }
+
+    @NotNull
+    public TabList.Entry asEntry() {
+        return new TabList.Entry(uniqueId, nickname, skin, true, 0, 0, tabFormat, 0, true);
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/ProxyPlayer.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/ProxyPlayer.java
@@ -1,4 +1,4 @@
-package me.neznamy.tab.shared.features.redis;
+package me.neznamy.tab.shared.features.proxy;
 
 import lombok.*;
 import me.neznamy.tab.shared.TabConstants.Permission;
@@ -14,7 +14,7 @@ import java.util.UUID;
  */
 @Getter
 @Setter
-public class RedisPlayer {
+public class ProxyPlayer {
 
     /** Tablist UUID of the player */
     @NotNull
@@ -87,7 +87,7 @@ public class RedisPlayer {
      * @param   staff
      *          Whether player has {@link Permission#STAFF} permission or not
      */
-    public RedisPlayer(@NotNull UUID uniqueId, @NotNull String name, @NotNull String nickname, @NotNull String server, boolean vanished, boolean staff) {
+    public ProxyPlayer(@NotNull UUID uniqueId, @NotNull String name, @NotNull String nickname, @NotNull String server, boolean vanished, boolean staff) {
         this.uniqueId = uniqueId;
         this.name = name;
         this.nickname = nickname;

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/Load.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/Load.java
@@ -1,14 +1,14 @@
-package me.neznamy.tab.shared.features.redis.message;
+package me.neznamy.tab.shared.features.proxy.message;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import lombok.NoArgsConstructor;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.platform.TabPlayer;
 import org.jetbrains.annotations.NotNull;
 
 @NoArgsConstructor
-public class Load extends RedisMessage {
+public class Load extends ProxyMessage {
 
     private TabPlayer[] players;
     private PlayerJoin[] decodedPlayers;
@@ -37,10 +37,10 @@ public class Load extends RedisMessage {
     }
 
     @Override
-    public void process(@NotNull RedisSupport redisSupport) {
+    public void process(@NotNull ProxySupport proxySupport) {
         for (PlayerJoin join : decodedPlayers) {
-            if (!redisSupport.getRedisPlayers().containsKey(join.getDecodedPlayer().getUniqueId())) {
-                join.process(redisSupport);
+            if (!proxySupport.getProxyPlayers().containsKey(join.getDecodedPlayer().getUniqueId())) {
+                join.process(proxySupport);
             }
         }
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/LoadRequest.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/LoadRequest.java
@@ -1,12 +1,12 @@
-package me.neznamy.tab.shared.features.redis.message;
+package me.neznamy.tab.shared.features.proxy.message;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import me.neznamy.tab.shared.TAB;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import org.jetbrains.annotations.NotNull;
 
-public class LoadRequest extends RedisMessage {
+public class LoadRequest extends ProxyMessage {
 
     @Override
     public void write(@NotNull ByteArrayDataOutput out) {
@@ -19,8 +19,8 @@ public class LoadRequest extends RedisMessage {
     }
 
     @Override
-    public void process(@NotNull RedisSupport redisSupport) {
-        redisSupport.sendMessage(new Load(TAB.getInstance().getOnlinePlayers()));
-        TAB.getInstance().getFeatureManager().onRedisLoadRequest();
+    public void process(@NotNull ProxySupport proxySupport) {
+        proxySupport.sendMessage(new Load(TAB.getInstance().getOnlinePlayers()));
+        TAB.getInstance().getFeatureManager().onProxyLoadRequest();
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/PlayerJoin.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/PlayerJoin.java
@@ -1,4 +1,4 @@
-package me.neznamy.tab.shared.features.redis.message;
+package me.neznamy.tab.shared.features.proxy.message;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
@@ -6,8 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.platform.TabList;
 import me.neznamy.tab.shared.platform.TabPlayer;
 import org.jetbrains.annotations.NotNull;
@@ -15,9 +15,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.UUID;
 
 @NoArgsConstructor
-public class PlayerJoin extends RedisMessage {
+public class PlayerJoin extends ProxyMessage {
 
-    @Getter private RedisPlayer decodedPlayer;
+    @Getter private ProxyPlayer decodedPlayer;
     private TabPlayer encodedPlayer;
 
     public PlayerJoin(@NotNull TabPlayer encodedPlayer) {
@@ -50,7 +50,7 @@ public class PlayerJoin extends RedisMessage {
         String server = in.readUTF();
         boolean vanished = in.readBoolean();
         boolean staff = in.readBoolean();
-        decodedPlayer = new RedisPlayer(uniqueId, name, name, server, vanished, staff);
+        decodedPlayer = new ProxyPlayer(uniqueId, name, name, server, vanished, staff);
 
         // Load skin immediately to make global playerlist stuff not too complicated
         if (in.readBoolean()) {
@@ -64,9 +64,9 @@ public class PlayerJoin extends RedisMessage {
     }
 
     @Override
-    public void process(@NotNull RedisSupport redisSupport) {
-        TAB.getInstance().debug("Processing join of redis player " + decodedPlayer.getName() + " (" + decodedPlayer.getUniqueId() + ")");
-        redisSupport.getRedisPlayers().put(decodedPlayer.getUniqueId(), decodedPlayer);
+    public void process(@NotNull ProxySupport proxySupport) {
+        TAB.getInstance().debug("Processing join of proxy player " + decodedPlayer.getName() + " (" + decodedPlayer.getUniqueId() + ")");
+        proxySupport.getProxyPlayers().put(decodedPlayer.getUniqueId(), decodedPlayer);
         TAB.getInstance().getFeatureManager().onJoin(decodedPlayer);
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/PlayerJoin.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/PlayerJoin.java
@@ -66,6 +66,11 @@ public class PlayerJoin extends ProxyMessage {
     @Override
     public void process(@NotNull ProxySupport proxySupport) {
         TAB.getInstance().debug("Processing join of proxy player " + decodedPlayer.getName() + " (" + decodedPlayer.getUniqueId() + ")");
+        // Do not create duplicated player
+        if (TAB.getInstance().isPlayerConnected(decodedPlayer.getUniqueId())) {
+            TAB.getInstance().debug("The player " + decodedPlayer.getName() + " is already connected");
+            return;
+        }
         proxySupport.getProxyPlayers().put(decodedPlayer.getUniqueId(), decodedPlayer);
         TAB.getInstance().getFeatureManager().onJoin(decodedPlayer);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/PlayerQuit.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/PlayerQuit.java
@@ -1,19 +1,19 @@
-package me.neznamy.tab.shared.features.redis.message;
+package me.neznamy.tab.shared.features.proxy.message;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import me.neznamy.tab.shared.TAB;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 @NoArgsConstructor
 @AllArgsConstructor
-public class PlayerQuit extends RedisMessage {
+public class PlayerQuit extends ProxyMessage {
 
     private UUID playerId;
 
@@ -28,14 +28,14 @@ public class PlayerQuit extends RedisMessage {
     }
 
     @Override
-    public void process(@NotNull RedisSupport redisSupport) {
-        RedisPlayer target = redisSupport.getRedisPlayers().get(playerId);
+    public void process(@NotNull ProxySupport proxySupport) {
+        ProxyPlayer target = proxySupport.getProxyPlayers().get(playerId);
         if (target == null) {
-            TAB.getInstance().getErrorManager().printError("Unable to process quit of redis player " + playerId + ", because no such player exists", null);
+            TAB.getInstance().getErrorManager().printError("Unable to process quit of proxy player " + playerId + ", because no such player exists", null);
             return;
         }
-        TAB.getInstance().debug("Processing quit of redis player " + target.getName());
+        TAB.getInstance().debug("Processing quit of proxy player " + target.getName());
         TAB.getInstance().getFeatureManager().onQuit(target);
-        redisSupport.getRedisPlayers().remove(target.getUniqueId());
+        proxySupport.getProxyPlayers().remove(target.getUniqueId());
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/PlayerQuit.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/PlayerQuit.java
@@ -35,7 +35,10 @@ public class PlayerQuit extends ProxyMessage {
             return;
         }
         TAB.getInstance().debug("Processing quit of proxy player " + target.getName());
-        TAB.getInstance().getFeatureManager().onQuit(target);
+        // Do not remove connected player
+        if (!TAB.getInstance().isPlayerConnected(target.getUniqueId())) {
+            TAB.getInstance().getFeatureManager().onQuit(target);
+        }
         proxySupport.getProxyPlayers().remove(target.getUniqueId());
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/ProxyMessage.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/ProxyMessage.java
@@ -1,15 +1,15 @@
-package me.neznamy.tab.shared.features.redis.message;
+package me.neznamy.tab.shared.features.proxy.message;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import me.neznamy.tab.shared.cpu.ThreadExecutor;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public abstract class RedisMessage {
+public abstract class ProxyMessage {
 
     @Nullable
     public ThreadExecutor getCustomThread() {
@@ -29,5 +29,5 @@ public abstract class RedisMessage {
 
     public abstract void read(@NotNull ByteArrayDataInput in);
 
-    public abstract void process(@NotNull RedisSupport redisSupport);
+    public abstract void process(@NotNull ProxySupport proxySupport);
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/ServerSwitch.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/ServerSwitch.java
@@ -1,19 +1,19 @@
-package me.neznamy.tab.shared.features.redis.message;
+package me.neznamy.tab.shared.features.proxy.message;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import me.neznamy.tab.shared.TAB;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 @NoArgsConstructor
 @AllArgsConstructor
-public class ServerSwitch extends RedisMessage {
+public class ServerSwitch extends ProxyMessage {
 
     private UUID playerId;
     private String newServer;
@@ -31,13 +31,13 @@ public class ServerSwitch extends RedisMessage {
     }
 
     @Override
-    public void process(@NotNull RedisSupport redisSupport) {
-        RedisPlayer target = redisSupport.getRedisPlayers().get(playerId);
+    public void process(@NotNull ProxySupport proxySupport) {
+        ProxyPlayer target = proxySupport.getProxyPlayers().get(playerId);
         if (target == null) {
-            TAB.getInstance().getErrorManager().printError("Unable to process server switch of redis player " + playerId + ", because no such player exists", null);
+            TAB.getInstance().getErrorManager().printError("Unable to process server switch of proxy player " + playerId + ", because no such player exists", null);
             return;
         }
-        TAB.getInstance().debug("Processing server switch of redis player " + target.getName());
+        TAB.getInstance().debug("Processing server switch of proxy player " + target.getName());
         target.setServer(newServer);
         TAB.getInstance().getFeatureManager().onServerSwitch(target);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/ServerSwitch.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/ServerSwitch.java
@@ -38,6 +38,10 @@ public class ServerSwitch extends ProxyMessage {
             return;
         }
         TAB.getInstance().debug("Processing server switch of proxy player " + target.getName());
+        if (TAB.getInstance().isPlayerConnected(target.getUniqueId())) {
+            TAB.getInstance().debug("The player " + target.getName() + " is already connected");
+            return;
+        }
         target.setServer(newServer);
         TAB.getInstance().getFeatureManager().onServerSwitch(target);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/UpdateVanishStatus.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/UpdateVanishStatus.java
@@ -1,19 +1,19 @@
-package me.neznamy.tab.shared.features.redis.message;
+package me.neznamy.tab.shared.features.proxy.message;
 
 import com.google.common.io.ByteArrayDataInput;
 import com.google.common.io.ByteArrayDataOutput;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import me.neznamy.tab.shared.TAB;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
 
 @NoArgsConstructor
 @AllArgsConstructor
-public class UpdateVanishStatus extends RedisMessage {
+public class UpdateVanishStatus extends ProxyMessage {
 
     private UUID playerId;
     private boolean vanished;
@@ -31,13 +31,13 @@ public class UpdateVanishStatus extends RedisMessage {
     }
 
     @Override
-    public void process(@NotNull RedisSupport redisSupport) {
-        RedisPlayer target = redisSupport.getRedisPlayers().get(playerId);
+    public void process(@NotNull ProxySupport proxySupport) {
+        ProxyPlayer target = proxySupport.getProxyPlayers().get(playerId);
         if (target == null) {
-            TAB.getInstance().getErrorManager().printError("Unable to process vanish status update of redis player " + playerId + ", because no such player exists", null);
+            TAB.getInstance().getErrorManager().printError("Unable to process vanish status update of proxy player " + playerId + ", because no such player exists", null);
             return;
         }
-        TAB.getInstance().debug("Processing vanish status update of redis player " + target.getName());
+        TAB.getInstance().debug("Processing vanish status update of proxy player " + target.getName());
         target.setVanished(vanished);
         TAB.getInstance().getFeatureManager().onVanishStatusChange(target);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/UpdateVanishStatus.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/proxy/message/UpdateVanishStatus.java
@@ -38,6 +38,11 @@ public class UpdateVanishStatus extends ProxyMessage {
             return;
         }
         TAB.getInstance().debug("Processing vanish status update of proxy player " + target.getName());
+        // Vanish status is already being processed by connected player
+        if (TAB.getInstance().isPlayerConnected(target.getUniqueId())) {
+            TAB.getInstance().debug("The player " + target.getName() + " is already connected");
+            return;
+        }
         target.setVanished(vanished);
         TAB.getInstance().getFeatureManager().onVanishStatusChange(target);
     }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/Sorting.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/Sorting.java
@@ -8,8 +8,8 @@ import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.features.layout.LayoutManagerImpl;
 import me.neznamy.tab.shared.features.nametags.NameTag;
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.features.sorting.types.*;
 import me.neznamy.tab.shared.features.types.JoinListener;
 import me.neznamy.tab.shared.features.types.Loadable;
@@ -29,7 +29,7 @@ public class Sorting extends RefreshableFeature implements SortingManager, JoinL
 
     private NameTag nameTags;
     private LayoutManagerImpl layout;
-    private RedisSupport redis;
+    private ProxySupport proxy;
     
     //map of all registered sorting types
     private final Map<String, BiFunction<Sorting, String, SortingType>> types = new LinkedHashMap<>();
@@ -80,7 +80,7 @@ public class Sorting extends RefreshableFeature implements SortingManager, JoinL
         // All of these features are instantiated after this one, so they must be detected later
         nameTags = TAB.getInstance().getNameTagManager();
         layout = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.LAYOUT);
-        redis = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.REDIS_BUNGEE);
+        proxy = TAB.getInstance().getFeatureManager().getFeature(TabConstants.Feature.PROXY_SUPPORT);
         for (TabPlayer all : TAB.getInstance().getOnlinePlayers()) {
             onJoin(all);
         }
@@ -163,8 +163,8 @@ public class Sorting extends RefreshableFeature implements SortingManager, JoinL
                     break;
                 }
             }
-            if (!nameTaken && redis != null && nameTags != null) {
-                for (RedisPlayer all : redis.getRedisPlayers().values()) {
+            if (!nameTaken && proxy != null && nameTags != null) {
+                for (ProxyPlayer all : proxy.getProxyPlayers().values()) {
                     if (potentialTeamName.equals(all.getTeamName())) {
                         nameTaken = true;
                         break;

--- a/shared/src/main/java/me/neznamy/tab/shared/features/types/ProxyFeature.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/types/ProxyFeature.java
@@ -1,18 +1,18 @@
 package me.neznamy.tab.shared.features.types;
 
-import me.neznamy.tab.shared.features.redis.RedisPlayer;
+import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Interface for features that hook into RedisSupport for displaying data
+ * Interface for features that hook into ProxySupport for displaying data
  * of players on other servers.
  */
-public interface RedisFeature {
+public interface ProxyFeature {
 
     /**
      * Called when another proxy is reloaded to request all data again.
      */
-    default void onRedisLoadRequest() {}
+    default void onProxyLoadRequest() {}
 
     /**
      * Called when a player joins another proxy.
@@ -20,7 +20,7 @@ public interface RedisFeature {
      * @param   player
      *          Player who joined
      */
-    default void onJoin(@NotNull RedisPlayer player) {}
+    default void onJoin(@NotNull ProxyPlayer player) {}
 
     /**
      * Called when a player quits another proxy.
@@ -28,21 +28,21 @@ public interface RedisFeature {
      * @param   player
      *          Player who left
      */
-    default void onQuit(@NotNull RedisPlayer player) {}
+    default void onQuit(@NotNull ProxyPlayer player) {}
 
     /**
-     * Called when vanish status of a redis player changes.
+     * Called when vanish status of a proxy player changes.
      *
      * @param   player
      *          Player with changed vanish status
      */
-    default void onVanishStatusChange(@NotNull RedisPlayer player) {}
+    default void onVanishStatusChange(@NotNull ProxyPlayer player) {}
 
     /**
-     * Called when a redis player switches server.
+     * Called when a proxy player switches server.
      *
      * @param   player
      *          Player who switched server
      */
-    default void onServerSwitch(@NotNull RedisPlayer player) {}
+    default void onServerSwitch(@NotNull ProxyPlayer player) {}
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
@@ -4,7 +4,7 @@ import me.neznamy.chat.component.TabComponent;
 import me.neznamy.tab.shared.GroupManager;
 import me.neznamy.tab.shared.features.PerWorldPlayerListConfiguration;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.features.types.TabFeature;
 import me.neznamy.tab.shared.placeholders.expansion.TabExpansion;
 import org.jetbrains.annotations.NotNull;
@@ -59,11 +59,11 @@ public interface Platform {
     @NotNull TabExpansion createTabExpansion();
 
     /**
-     * Creates RedisSupport feature, registers listeners and returns it
+     * Creates ProxySupport feature, registers listeners and returns it
      *
      * @return  Created instance
      */
-    @Nullable RedisSupport getRedisSupport();
+    @Nullable ProxySupport getProxySupport(@NotNull String plugin);
 
     /**
      * Returns per world player list feature handler.

--- a/shared/src/main/resources/config/config.yml
+++ b/shared/src/main/resources/config/config.yml
@@ -237,6 +237,11 @@ proxy-support:
     # Compatible plugins: RedisBungee
     # If enabled and compatible plugin is found, hook is enabled to work with proxied players
     name: RedisBungee
+  redis:
+    url: 'redis://:password@localhost:6379/0'
+  rabbitmq:
+    exchange: 'plugin'
+    url: 'amqp://guest:guest@localhost:5672/%2F'
 
 ########################################################################
 # BUKKIT ONLY - THE FOLLOWING SECTION IS ONLY FOR BACKEND INSTALLATION #

--- a/shared/src/main/resources/config/config.yml
+++ b/shared/src/main/resources/config/config.yml
@@ -229,6 +229,15 @@ mysql:
   password: password
   useSSL: true
 
+proxy-support:
+  enabled: true
+  # Types: PLUGIN
+  type: PLUGIN
+  plugin:
+    # Compatible plugins: RedisBungee
+    # If enabled and compatible plugin is found, hook is enabled to work with proxied players
+    name: RedisBungee
+
 ########################################################################
 # BUKKIT ONLY - THE FOLLOWING SECTION IS ONLY FOR BACKEND INSTALLATION #
 ########################################################################
@@ -281,6 +290,3 @@ use-bukkit-permissions-manager: false
 # If you experience tablist formatting not working, toggle this option (set it to opposite value)
 # Only affects proxies with online mode enabled
 use-online-uuid-in-tablist: true
-
-# If enabled and RedisBungee plugin is found, hook is enabled to work with players on all proxies
-enable-redisbungee-support: true

--- a/shared/src/main/resources/config/config.yml
+++ b/shared/src/main/resources/config/config.yml
@@ -231,7 +231,7 @@ mysql:
 
 proxy-support:
   enabled: true
-  # Types: PLUGIN
+  # Supported types: PLUGIN, REDIS, RABBITMQ
   type: PLUGIN
   plugin:
     # Compatible plugins: RedisBungee

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
@@ -15,7 +15,7 @@ import me.neznamy.chat.TextColor;
 import me.neznamy.chat.component.TabComponent;
 import me.neznamy.chat.component.TextComponent;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import me.neznamy.tab.shared.platform.BossBar;
 import me.neznamy.tab.shared.platform.Scoreboard;
 import me.neznamy.tab.shared.platform.TabList;
@@ -101,10 +101,12 @@ public class VelocityPlatform extends ProxyPlatform {
 
     @Override
     @Nullable
-    public RedisSupport getRedisSupport() {
-        if (ReflectionUtils.classExists("com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI") &&
-                RedisBungeeAPI.getRedisBungeeApi() != null) {
-            return new VelocityRedisSupport(plugin);
+    public ProxySupport getProxySupport(@NotNull String plugin) {
+        if (plugin.equalsIgnoreCase("RedisBungee")) {
+            if (ReflectionUtils.classExists("com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI") &&
+                    RedisBungeeAPI.getRedisBungeeApi() != null) {
+                return new VelocityRedisSupport(this.plugin);
+            }
         }
         return null;
     }

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/features/VelocityRedisSupport.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/features/VelocityRedisSupport.java
@@ -7,14 +7,14 @@ import lombok.AllArgsConstructor;
 import me.neznamy.tab.platforms.velocity.VelocityTAB;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
-import me.neznamy.tab.shared.features.redis.RedisSupport;
+import me.neznamy.tab.shared.features.proxy.ProxySupport;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * RedisBungee implementation for Velocity
  */
 @AllArgsConstructor
-public class VelocityRedisSupport extends RedisSupport {
+public class VelocityRedisSupport extends ProxySupport {
 
     /** Plugin reference for registering listener */
     @NotNull
@@ -28,26 +28,26 @@ public class VelocityRedisSupport extends RedisSupport {
      */
     @Subscribe
     public void onMessage(PubSubMessageEvent e) {
-        if (!e.getChannel().equals(TabConstants.REDIS_CHANNEL_NAME)) return;
+        if (!e.getChannel().equals(TabConstants.PROXY_CHANNEL_NAME)) return;
         processMessage(e.getMessage());
     }
 
     @Override
     public void register() {
         plugin.getServer().getEventManager().register(plugin, this);
-        RedisBungeeAPI.getRedisBungeeApi().registerPubSubChannels(TabConstants.REDIS_CHANNEL_NAME);
+        RedisBungeeAPI.getRedisBungeeApi().registerPubSubChannels(TabConstants.PROXY_CHANNEL_NAME);
     }
 
     @Override
     public void unregister() {
         plugin.getServer().getEventManager().unregisterListener(plugin, this);
-        RedisBungeeAPI.getRedisBungeeApi().unregisterPubSubChannels(TabConstants.REDIS_CHANNEL_NAME);
+        RedisBungeeAPI.getRedisBungeeApi().unregisterPubSubChannels(TabConstants.PROXY_CHANNEL_NAME);
     }
 
     @Override
     public void sendMessage(@NotNull String message) {
         try {
-            RedisBungeeAPI.getRedisBungeeApi().sendChannelMessage(TabConstants.REDIS_CHANNEL_NAME, message);
+            RedisBungeeAPI.getRedisBungeeApi().sendChannelMessage(TabConstants.PROXY_CHANNEL_NAME, message);
         } catch (Exception e) {
             TAB.getInstance().getErrorManager().redisBungeeMessageSendFail(e);
         }


### PR DESCRIPTION
## Redis support -> Proxy support
First of all, any redis-related feature name was renamed to "proxy feature".

### Why?
* I was looking on TAB code to find a solution for multi-server support without using TAB on proxies.
* I find out a pretty well-made feature to transfer messages across proxies wasted on RedisBungee messaging.
* I ~~don't want to mantain this feature with future TAB API updates~~ like to share any plugin edit.

### How it works?
```yaml
proxy-support:
  enabled: true
  # Supported types: PLUGIN, REDIS, RABBITMQ
  type: PLUGIN
  plugin:
    # Compatible plugins: RedisBungee
    # If enabled and compatible plugin is found, hook is enabled to work with proxied players
    name: RedisBungee
  redis:
    url: 'redis://:password@localhost:6379/0'
  rabbitmq:
    exchange: 'plugin'
    url: 'amqp://guest:guest@localhost:5672/%2F'

# On backend servers you should set this option with the ID of the server as defined in your proxy config.
server-name: 'server'
```
By default, the functionality is the same as RedisBungee support configuration.
Adding compatibility for Redis and RabbitMQ using [delivery4j](https://github.com/saicone/delivery4j) library.

**On proxy servers**, it works with global player list.
**On backend servers**, it make global player list work.

### For people that still using TAB v4
I made the same changes on this branch: https://github.com/MineLAT/TAB/tree/v4
You should compile it by yourself.

> [!NOTE]  
> I also add [RGB support on pre 1.16 servers](https://github.com/MineLAT/TAB/commit/f0848c5cd32122d0cd16614dbe1364c89e17ee92) using TAB v4 + ViaVersion, tell me if you want that implementation on TAB v5 to make a pull request later.