### PR TITLE
Add basic implementation of the new tab list sorting feature (1.21.2)

### DIFF
--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/BukkitTabPlayer.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/BukkitTabPlayer.java
@@ -2,15 +2,20 @@ package me.neznamy.tab.platforms.bukkit;
 
 import lombok.Getter;
 import lombok.SneakyThrows;
+import me.neznamy.chat.component.SimpleTextComponent;
 import me.neznamy.chat.component.TabComponent;
 import me.neznamy.tab.platforms.bukkit.hook.LibsDisguisesHook;
 import me.neznamy.tab.platforms.bukkit.platform.BukkitPlatform;
+import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.backend.BackendTabPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 /**
  * TabPlayer implementation for Bukkit platform
@@ -99,5 +104,18 @@ public class BukkitTabPlayer extends BackendTabPlayer {
     @NotNull
     public String getDisplayName() {
         return getPlayer().getDisplayName();
+    }
+
+    @Override
+    public void setTabPosition(int position) {
+        try {
+            Method m = getPlayer().getClass().getMethod("setPlayerListOrder", int.class);
+            //m.setAccessible(true); // Why is this needed? The method is public!
+            m.invoke(getPlayer(), position);
+        } catch (NoSuchMethodException e) {
+            TAB.getInstance().getPlatform().logWarn(SimpleTextComponent.text("Couldn't find the method setPlayerListOrder. Did you enable the new-tablist-sorting while being in a version inferior to 1.21.2 ?"));
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeeTabPlayer.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeeTabPlayer.java
@@ -68,4 +68,9 @@ public class BungeeTabPlayer extends ProxyTabPlayer {
     public void sendPacket(@NotNull DefinedPacket packet) {
         ((UserConnection)getPlayer()).sendPacketQueued(packet);
     }
+
+    @Override
+    public void setTabPosition(int position) {
+        throw new RuntimeException("Not implemented");
+    }
 }

--- a/fabric/src/main/java/me/neznamy/tab/platforms/fabric/FabricTabPlayer.java
+++ b/fabric/src/main/java/me/neznamy/tab/platforms/fabric/FabricTabPlayer.java
@@ -81,4 +81,9 @@ public class FabricTabPlayer extends BackendTabPlayer {
     public String getDisplayName() {
         return getPlayer().getGameProfile().getName(); // Will make it work properly if someone asks
     }
+
+    @Override
+    public void setTabPosition(int position) {
+        throw new RuntimeException("Not implemented");
+    }
 }

--- a/forge/src/main/java/me/neznamy/tab/platforms/forge/ForgeTabPlayer.java
+++ b/forge/src/main/java/me/neznamy/tab/platforms/forge/ForgeTabPlayer.java
@@ -81,4 +81,9 @@ public class ForgeTabPlayer extends BackendTabPlayer {
     public String getDisplayName() {
         return getPlayer().getGameProfile().getName(); // Will make it work properly if someone asks
     }
+
+    @Override
+    public void setTabPosition(int position) {
+        throw new RuntimeException("Not implemented");
+    }
 }

--- a/neoforge/src/main/java/me/neznamy/tab/platforms/neoforge/NeoForgeTabPlayer.java
+++ b/neoforge/src/main/java/me/neznamy/tab/platforms/neoforge/NeoForgeTabPlayer.java
@@ -81,4 +81,9 @@ public class NeoForgeTabPlayer extends BackendTabPlayer {
     public String getDisplayName() {
         return getPlayer().getGameProfile().getName(); // Will make it work properly if someone asks
     }
+
+    @Override
+    public void setTabPosition(int position) {
+        throw new RuntimeException("Not implemented");
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/config/Converter.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/Converter.java
@@ -520,4 +520,20 @@ public class Converter {
         config.setIfMissing("playerlist-objective.title", "Java Edition is better");
         config.setIfMissing("playerlist-objective.render-type", Arrays.asList("%health%", "%player_health%", "%player_health_rounded%").contains(config.getString("playerlist-objective.value", "")) ? "HEARTS" : "INTEGER");
     }
+
+    /**
+     * Converts config from 5.2.0 to 5.2.1
+     * This update:
+     * - Creates the option proxy-support and removes the old enable-redisbungee-support configuration.
+     * - Renames placeholderapi-refresh-intervals to placeholder-refresh-intervals
+     * - Adds new playerlist objective options
+     *
+     * @param   config
+     *          Config file
+     */
+    public void convert520to521(@NotNull ConfigurationFile config) {
+        if (!config.hasConfigOption("new-tablist-sorting")) {
+            config.set("new-tablist-sorting", false);
+        }
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/config/files/Config.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/files/Config.java
@@ -80,6 +80,7 @@ public class Config {
         converter.convert419to500(config);
         converter.convert501to502(config);
         converter.convert507to510(config);
+        converter.convert520to521(config);
 
         conditions = ConditionsSection.fromSection(config.getConfigurationSection("conditions"));
         refresh = PlaceholderRefreshConfiguration.fromSection(config.getConfigurationSection("placeholder-refresh-intervals"));
@@ -95,7 +96,7 @@ public class Config {
         if (config.getBoolean("ping-spoof.enabled", false)) pingSpoof = PingSpoofConfiguration.fromSection(config.getConfigurationSection("ping-spoof"));
         if (config.getBoolean("playerlist-objective.enabled", true)) playerlistObjective = PlayerListObjectiveConfiguration.fromSection(config.getConfigurationSection("playerlist-objective"));
         if (config.getBoolean("scoreboard.enabled", false)) scoreboard = ScoreboardConfiguration.fromSection(config.getConfigurationSection("scoreboard"));
-        if (config.getBoolean("scoreboard-teams.enabled", true) || config.getBoolean("layout.enabled", false)) sorting = SortingConfiguration.fromSection(config.getConfigurationSection("scoreboard-teams"));
+        if (config.getBoolean("scoreboard-teams.enabled", true) || config.getBoolean("layout.enabled", false) || config.getBoolean("new-tablist-sorting", false)) sorting = SortingConfiguration.fromSection(config.getConfigurationSection("scoreboard-teams"), config.getBoolean("new-tablist-sorting", false));
         if (config.getBoolean("tablist-name-formatting.enabled", false)) tablistFormatting = TablistFormattingConfiguration.fromSection(config.getConfigurationSection("tablist-name-formatting"));
         if (config.getBoolean("scoreboard-teams.enabled", false)) teams = TeamConfiguration.fromSection(config.getConfigurationSection("scoreboard-teams"));
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/Sorting.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/Sorting.java
@@ -67,11 +67,15 @@ public class Sorting extends RefreshableFeature implements SortingManager, JoinL
 
     @Override
     public void refresh(@NotNull TabPlayer p, boolean force) {
-        String previousShortName = p.sortingData.shortTeamName;
-        constructTeamNames(p);
-        if (!p.sortingData.shortTeamName.equals(previousShortName)) {
-            if (nameTags != null) nameTags.updateTeamName(p, p.sortingData.getShortTeamName());
-            if (layout != null) layout.updateTeamName(p, p.sortingData.getFullTeamName());
+        if(configuration.isNewTabListSorting()) {
+            updatePosition(p);
+        } else {
+            String previousShortName = p.sortingData.shortTeamName;
+            constructTeamNames(p);
+            if (!p.sortingData.shortTeamName.equals(previousShortName)) {
+                if (nameTags != null) nameTags.updateTeamName(p, p.sortingData.getShortTeamName());
+                if (layout != null) layout.updateTeamName(p, p.sortingData.getFullTeamName());
+            }
         }
     }
 
@@ -88,7 +92,11 @@ public class Sorting extends RefreshableFeature implements SortingManager, JoinL
     
     @Override
     public void onJoin(@NotNull TabPlayer connectedPlayer) {
-        constructTeamNames(connectedPlayer);
+        if(configuration.isNewTabListSorting()) {
+            updatePosition(connectedPlayer);
+        } else {
+            constructTeamNames(connectedPlayer);
+        }
     }
     
     /**
@@ -176,6 +184,20 @@ public class Sorting extends RefreshableFeature implements SortingManager, JoinL
             }
             id++;
         }
+    }
+
+    /**
+     * Updates the player's position in the tab list using the new sorting feature
+     * @param p
+     *        player to update the position
+     */
+    public void updatePosition(@NotNull TabPlayer p) {
+        p.sortingData.teamNameNote = "";
+        int position = 0;
+        for (SortingType type : usedSortingTypes) {
+            position += type.getPosition(p);
+        }
+        p.setTabPosition(position);
     }
     
     /**

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/SortingConfiguration.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/SortingConfiguration.java
@@ -17,6 +17,7 @@ public class SortingConfiguration {
 
     private final boolean caseSensitiveSorting;
     private final List<String> sortingTypes;
+    private final boolean newTabListSorting;
 
     /**
      * Returns instance of this class created from given configuration section. If there are
@@ -27,10 +28,11 @@ public class SortingConfiguration {
      * @return  Loaded instance from given configuration section
      */
     @NotNull
-    public static SortingConfiguration fromSection(@NotNull ConfigurationSection section) {
+    public static SortingConfiguration fromSection(@NotNull ConfigurationSection section, boolean newTabListSorting) {
         return new SortingConfiguration(
                 section.getBoolean("case-sensitive-sorting", true),
-                section.getStringList("sorting-types", Collections.emptyList())
+                section.getStringList("sorting-types", Collections.emptyList()),
+                newTabListSorting
         );
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/Groups.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/Groups.java
@@ -31,6 +31,11 @@ public class Groups extends SortingType {
 
     @Override
     public String getChars(@NotNull TabPlayer p) {
+        return String.valueOf((char) (getPosition(p) + 47));
+    }
+
+    @Override
+    public int getPosition(@NotNull TabPlayer p) {
         String group = p.getGroup().toLowerCase();
         int position;
         if (!sortedGroups.containsKey(group)) {
@@ -41,6 +46,6 @@ public class Groups extends SortingType {
             position = sortedGroups.get(group);
             p.sortingData.teamNameNote += "\n-> Primary group (&e" + p.getGroup() + "&r) is &a#" + position + "&r in sorting list.";
         }
-        return String.valueOf((char) (position + 47));
+        return position;
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/Permissions.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/Permissions.java
@@ -42,6 +42,11 @@ public class Permissions extends SortingType {
 
     @Override
     public String getChars(@NotNull TabPlayer p) {
+        return String.valueOf((char) (getPosition(p) + 47));
+    }
+
+    @Override
+    public int getPosition(@NotNull TabPlayer p) {
         int position = 0;
         for (String permission : sortedGroups.keySet()) {
             if (p.hasPermission(permission)) {
@@ -58,6 +63,6 @@ public class Permissions extends SortingType {
             position = sortedGroups.size()+1;
             p.sortingData.teamNameNote += "\n-> &cPlayer does not have any of the defined permissions. &r";
         }
-        return String.valueOf((char) (position + 47));
+        return position;
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/Placeholder.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/Placeholder.java
@@ -61,6 +61,12 @@ public class Placeholder extends SortingType {
     @Override
     public String getChars(@NotNull TabPlayer p) {
         if (!valid) return "";
+        return String.valueOf((char) (getPosition(p) + 47));
+    }
+
+    @Override
+    public int getPosition(@NotNull TabPlayer p) {
+        if (!valid) return 0;
         String output = EnumChatFormat.color(setPlaceholders(p));
         p.sortingData.teamNameNote += "\n-> " + sortingPlaceholder + " returned \"&e" + output + "&r\"";
         int position;
@@ -73,6 +79,6 @@ public class Placeholder extends SortingType {
             position = sortingMap.get(cleanOutput);
             p.sortingData.teamNameNote += "&r &a(#" + position + " in list). &r";
         }
-        return String.valueOf((char) (position + 47));
+        return position;
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/PlaceholderAtoZ.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/PlaceholderAtoZ.java
@@ -27,4 +27,33 @@ public class PlaceholderAtoZ extends SortingType {
         p.sortingData.teamNameNote += "\n-> " + sortingPlaceholder + " returned \"&e" + output + "&r\". &r";
         return sorting.getConfiguration().isCaseSensitiveSorting() ? output : output.toLowerCase();
     }
+
+    @Override
+    public int getPosition(@NotNull TabPlayer p) {
+        String s = getChars(p);
+
+        double weight = 0.0;
+        double factor = 1.0;
+
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            int value;
+
+            if (Character.isUpperCase(c)) {
+                value = c - 'A' + 1; // A = 1, B = 2, ..., Z = 26
+            } else if (Character.isLowerCase(c)) {
+                value = c - 'a' + 27; // a = 27, b = 28, ..., z = 52
+            } else {
+                // Ignore other chars
+                value = 0;
+            }
+
+            factor /= 53.0; // base 53 (26 uppercase + 26 lowercase + 1 to avoid 0)
+            weight += value * factor;
+        }
+
+        double ratio = 1.0 - weight; // always between 1 and 0
+
+        return (int) ratio * 10000000;
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/PlaceholderHighToLow.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/PlaceholderHighToLow.java
@@ -28,4 +28,12 @@ public class PlaceholderHighToLow extends SortingType {
         p.sortingData.teamNameNote += "\n-> " + sortingPlaceholder + " returned \"&e" + output + "&r\". &r";
         return compressNumber(DEFAULT_NUMBER - parseDouble(sortingPlaceholder, output, 0, p));
     }
+
+    @Override
+    public int getPosition(@NotNull TabPlayer p) {
+        if (!valid) return 0;
+        String output = setPlaceholders(p);
+        p.sortingData.teamNameNote += "\n-> " + sortingPlaceholder + " returned \"&e" + output + "&r\". &r";
+        return (int) (DEFAULT_NUMBER + parseDouble(sortingPlaceholder, output, 0, p));
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/PlaceholderLowToHigh.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/PlaceholderLowToHigh.java
@@ -28,4 +28,12 @@ public class PlaceholderLowToHigh extends SortingType {
         p.sortingData.teamNameNote += "\n-> " + sortingPlaceholder + " returned \"&e" + output + "&r\". &r";
         return compressNumber(DEFAULT_NUMBER + parseDouble(sortingPlaceholder, output, 0, p));
     }
+
+    @Override
+    public int getPosition(@NotNull TabPlayer p) {
+        if (!valid) return 0;
+        String output = setPlaceholders(p);
+        p.sortingData.teamNameNote += "\n-> " + sortingPlaceholder + " returned \"&e" + output + "&r\". &r";
+        return (int) (DEFAULT_NUMBER - parseDouble(sortingPlaceholder, output, 0, p));
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/PlaceholderZtoA.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/PlaceholderZtoA.java
@@ -37,4 +37,30 @@ public class PlaceholderZtoA extends SortingType {
         String s = new String(chars);
         return sorting.getConfiguration().isCaseSensitiveSorting() ? s : s.toLowerCase();
     }
+
+    @Override
+    public int getPosition(@NotNull TabPlayer p) {
+        String s = getChars(p);
+
+        double weight = 0.0;
+        double factor = 1.0;
+
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            int value;
+
+            if (Character.isUpperCase(c)) {
+                value = 'Z' - c + 1; // Z = 1, ..., A = 26
+            } else if (Character.isLowerCase(c)) {
+                value = 'z' - c + 27; // z = 27, ..., a = 52
+            } else {
+                value = 0; // other chars are ignored
+            }
+
+            factor /= 53.0;
+            weight += value * factor;
+        }
+
+        return (int) weight * 10000000;
+    }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/SortingType.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/sorting/types/SortingType.java
@@ -144,4 +144,13 @@ public abstract class SortingType {
      * @return  an as-short-as-possible character sequence for unique sorting
      */
     public abstract String getChars(@NotNull TabPlayer p);
+
+    /**
+     * Returns current sorting position of this sorting type for specified player
+     *
+     * @param   p
+     *          player to get position for
+     * @return  an integer representing the tab list position
+     */
+    public abstract int getPosition(@NotNull TabPlayer p);
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/TabPlayer.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/TabPlayer.java
@@ -397,4 +397,12 @@ public abstract class TabPlayer implements me.neznamy.tab.api.TabPlayer {
      * @return  Server platform
      */
     public abstract Platform getPlatform();
+
+    /**
+     * Set the tab position. Only possible from 1.21.2
+     *
+     * @param   position
+     *          The position to set. The greater the value, the higher in the tab list
+     */
+    public abstract void setTabPosition(int position);
 }

--- a/sponge/src/main/java/me/neznamy/tab/platforms/sponge/SpongeTabPlayer.java
+++ b/sponge/src/main/java/me/neznamy/tab/platforms/sponge/SpongeTabPlayer.java
@@ -94,4 +94,9 @@ public class SpongeTabPlayer extends BackendTabPlayer {
     public String getDisplayName() {
         return PlainTextComponentSerializer.plainText().serialize(getPlayer().displayName().get());
     }
+
+    @Override
+    public void setTabPosition(int position) {
+        throw new RuntimeException("Not implemented");
+    }
 }

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTabPlayer.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityTabPlayer.java
@@ -57,4 +57,9 @@ public class VelocityTabPlayer extends ProxyTabPlayer {
             // java.lang.IllegalStateException: Not connected to server!
         }
     }
+
+    @Override
+    public void setTabPosition(int position) {
+        getPlayer().getTabList().getEntry(getPlayer().getUniqueId()).ifPresent(entry -> entry.setListOrder(position));
+    }
 }


### PR DESCRIPTION
Hello ! 
I create this PR in order to support the new feature allowing in newer versions to sort players without teams ([Velocity](https://jd.papermc.io/velocity/3.4.0/com/velocitypowered/api/proxy/player/TabListEntry.html#setListOrder(int)), [Paper](https://jd.papermc.io/paper/1.21.5/org/bukkit/entity/Player.html#setPlayerListOrder(int)) ).

This is only a basic implementation and many things could/should be changed. Here is a small list of the choices I made or things that should be looked at : 

- [ ] The config option is currently `new-tablist-sorting`. Might be a good idea to rename it or move it to a proper config section.
- [ ] Add a "weight" system to the SortingTypes so that if SortingType A with a position at 5 and SortingType B with a position at 10 is not the same as SortingType A with a position at 10 and SortingType B with a position at 5
- [ ] Properly test each `SortingType#getPosition()`. I only tested the one I used : PlaceholderHighToLow and PlaceholderLowToHigh
- [ ] "new tab list sorting" is kind of ugly but I couldn't find a better name for each variables or config option
- [ ] Search if this option could be used on BungeeCord, Fabric, Forge, Neoforge and Sponge and implement the method `public void setTabPosition(int position)` in their TabPlayer implementations.

I really think that this new feature allowing to sort the tab list without using teams is great and should be used even if it is not the way that I am suggesting.
I allowed edits from maintainers so that you could change it the way you would've liked it :)  