### PR TITLE
Fix: Compilation errors showing generated src instead of actual src -> introducing blossom 2.1.0

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("net.kyori.blossom") version "1.3.1"
+    id("net.kyori.blossom") version "2.1.0"
 }
 
 dependencies {
@@ -32,13 +32,16 @@ dependencies {
     implementation("com.saicone.delivery4j:extension-guava:1.1.1")
 }
 
-blossom {
-    replaceToken("@name@", rootProject.name)
-    replaceToken("@id@", rootProject.ext.get("id")!!.toString())
-    replaceToken("@version@", project.version)
-    replaceToken("@description@", project.description)
-    replaceToken("@website@", rootProject.ext.get("website")!!.toString())
-    replaceToken("@author@", rootProject.ext.get("author")!!.toString())
-    replaceToken("@credits@", rootProject.ext.get("credits")!!.toString())
-    replaceTokenIn("src/main/java/me/neznamy/tab/shared/TabConstants.java")
+sourceSets.main {
+    blossom {
+        javaSources {
+            property("name", rootProject.name)
+            property("id", rootProject.ext.get("id")!!.toString())
+            property("version", project.version.toString())
+            property("description", project.description)
+            property("website", rootProject.ext.get("website")!!.toString())
+            property("author", rootProject.ext.get("author")!!.toString())
+            property("credits", rootProject.ext.get("credits")!!.toString())
+        }
+    }
 }

--- a/shared/src/main/java-templates/me/neznamy/tab/shared/TabConstants.java
+++ b/shared/src/main/java-templates/me/neznamy/tab/shared/TabConstants.java
@@ -11,12 +11,12 @@ import org.jetbrains.annotations.NotNull;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TabConstants {
 
-    public static final String PLUGIN_NAME = "@name@";
-    public static final String PLUGIN_ID = "@id@";
-    public static final String PLUGIN_VERSION = "@version@";
-    public static final String PLUGIN_DESCRIPTION = "@description@";
-    public static final String PLUGIN_WEBSITE = "@website@";
-    public static final String PLUGIN_AUTHOR = "@author@";
+    public static final String PLUGIN_NAME = "{{ name }}";
+    public static final String PLUGIN_ID = "{{ id }}";
+    public static final String PLUGIN_VERSION = "{{ version }}";
+    public static final String PLUGIN_DESCRIPTION = "{{ description }}";
+    public static final String PLUGIN_WEBSITE = "{{ website }}";
+    public static final String PLUGIN_AUTHOR = "{{ author }}";
 
     public static final String NO_GROUP = "NONE";
     public static final String DEFAULT_GROUP = "_DEFAULT_";


### PR DESCRIPTION
### Key changes
- Changing plugin version from 1.3.1 to 2.1.0
- Adapt TabConstants.java to new token syntax "@x@" -> {{ x }}
- Changing corresponding gradle.build.kts to match new blossom version

### To acknowledge
Files that are located in the resources directories are not impacted by this change, as you already handle processResources in your tab.base-conventions.gradle.kts

This change basically only impacts the TabConstants file, due to its functionality. Making the development environment more friendly.

Thanks for considering!
Please contact me if any questions persist. 