### PR TITLE
Packet Handling Safety Enhancement - Null Packet Protection

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/injection/NettyPipelineInjector.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/injection/NettyPipelineInjector.java
@@ -65,6 +65,10 @@ public abstract class NettyPipelineInjector extends PipelineInjector {
         @Override
         public void write(ChannelHandlerContext context, Object packet, ChannelPromise channelPromise) {
             try {
+                if (packet == null) {
+                    return;
+                }
+                
                 if (player.getVersion().getMinorVersion() >= 8) {
                     ((TrackedTabList<?>)player.getTabList()).onPacketSend(packet);
                 }


### PR DESCRIPTION
Hello @NEZNAMY,

We've identified and fixed a potential issue in the `NettyPipelineInjector.java` where null packets could cause downstream processing errors when multiple packet-modifying plugins are used together.

**Changes made:**
- Added null packet validation in `TabChannelDuplexHandler.write()` method
- Added early return when packet is null to prevent further processing

**Why this change is needed:**
When TAB is used alongside other packet-intercepting plugins (like PetNameFix, AxTrade), there are edge cases where packets can become null or corrupted during the pipeline processing. Without this check, TAB would attempt to process these invalid packets, potentially causing cascading errors in the plugin chain.

**Benefits:**
- Prevents NullPointerException when processing corrupted packets
- Improves stability when used with other packet-modifying plugins
- Maintains TAB's functionality while adding defensive programming

This is a minimal, non-breaking change that enhances TAB's robustness in multi-plugin environments.

**My log:**
```
[15:01:52] [Netty Epoll Server IO #2/ERROR]: Error sending packet clientbound/minecraft:set_entity_data
io.netty.handler.codec.EncoderException: Failed to encode packet 'clientbound/minecraft:set_entity_data'
	at net.minecraft.network.codec.IdDispatchCodec.encode(IdDispatchCodec.java:62) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.codec.IdDispatchCodec.encode(IdDispatchCodec.java:13) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.PacketEncoder.encode(PacketEncoder.java:27) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.PacketEncoder.encode(PacketEncoder.java:12) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:107) ~[netty-codec-base-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:827) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.handler.codec.MessageToMessageEncoder.writeVoidPromise(MessageToMessageEncoder.java:133) ~[netty-codec-base-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.handler.codec.MessageToMessageEncoder.write(MessageToMessageEncoder.java:118) ~[netty-codec-base-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:827) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.handler.codec.MessageToByteEncoder.write(MessageToByteEncoder.java:120) ~[netty-codec-base-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:827) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.ChannelOutboundHandlerAdapter.write(ChannelOutboundHandlerAdapter.java:113) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at net.minecraft.network.Connection$2.write(Connection.java:767) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:827) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:115) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at TAB-5.3.0-SNAPSHOT+1845.jar/me.neznamy.tab.shared.features.injection.NettyPipelineInjector$TabChannelDuplexHandler.write(NettyPipelineInjector.java:76) ~[TAB-5.3.0-SNAPSHOT+1845.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:825) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:115) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at PetNameFix-1.0.4.jar/io.github.tanguygab.petnamefix.PipelineInjector$BukkitChannelDuplexHandler.write(PipelineInjector.java:89) ~[PetNameFix-1.0.4.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:825) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.ChannelDuplexHandler.write(ChannelDuplexHandler.java:115) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at AxTrade-1.19.2.jar/com.artillexstudios.axtrade.libs.axapi.nms.v1_21_R5.packet.ChannelDuplexHandlerPacketListener.write(ChannelDuplexHandlerPacketListener.java:114) ~[AxTrade-1.19.2.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:825) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:752) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.ChannelOutboundHandlerAdapter.write(ChannelOutboundHandlerAdapter.java:113) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at Vulcan-2.9.7.2.jar/dev.thomazz.pledge.network.Vulcan_AA.write(Vulcan_AA.java:45) ~[Vulcan-2.9.7.2.jar:?]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:827) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:804) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1041) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.Channel.writeAndFlush(Channel.java:262) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at ProtocolLib.jar/com.comphenix.protocol.injector.netty.channel.NettyChannelProxy.writeAndFlush(NettyChannelProxy.java:227) ~[ProtocolLib.jar:?]
	at net.minecraft.network.Connection.doSendPacket(Connection.java:539) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.Connection.lambda$sendPacket$16(Connection.java:521) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at ProtocolLib.jar/com.comphenix.protocol.injector.netty.channel.NettyChannelInjector.lambda$proxyAction$7(NettyChannelInjector.java:566) ~[ProtocolLib.jar:?]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:148) ~[netty-common-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:141) ~[netty-common-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:535) ~[netty-common-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:201) ~[netty-transport-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1193) ~[netty-common-4.2.6.Final.jar:4.2.6.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.2.6.Final.jar:4.2.6.Final]
	at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: java.lang.NullPointerException: Cannot invoke "net.minecraft.network.syncher.SynchedEntityData$DataValue.write(net.minecraft.network.RegistryFriendlyByteBuf)" because "dataValue" is null
	at net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket.pack(ClientboundSetEntityDataPacket.java:24) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.protocol.game.ClientboundSetEntityDataPacket.write(ClientboundSetEntityDataPacket.java:44) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.codec.StreamCodec$2.encode(StreamCodec.java:42) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.codec.StreamCodec$5.encode(StreamCodec.java:92) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.codec.StreamCodec$5.encode(StreamCodec.java:82) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	at net.minecraft.network.codec.IdDispatchCodec.encode(IdDispatchCodec.java:57) ~[leaf-1.21.8.jar:1.21.8-113-6949bed]
	... 46 more
```

Also opened PR to PetNameFix: https://github.com/Tanguygab/PetNameFix/pull/5