### PR TITLE
Add customnametag support for placeholder-based player names in nametags [example]

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTag.java
@@ -105,6 +105,9 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
             refresh = prefix || suffix;
         }
         if (refresh) updatePrefixSuffix(refreshed);
+        if (refreshed.teamData.customName != null && refreshed.teamData.customName.update()) {
+            updatePrefixSuffix(refreshed);
+        }
     }
 
     @Override
@@ -217,6 +220,7 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
     private void loadProperties(@NotNull TabPlayer player) {
         player.teamData.prefix = player.loadPropertyFromConfig(this, "tagprefix", "");
         player.teamData.suffix = player.loadPropertyFromConfig(this, "tagsuffix", "");
+        player.teamData.customName = player.loadPropertyFromConfig(this, "customnametag", null);
     }
 
     /**
@@ -230,6 +234,7 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
     private boolean updateProperties(@NotNull TabPlayer p) {
         boolean changed = p.updatePropertyFromConfig(p.teamData.prefix, "");
         if (p.updatePropertyFromConfig(p.teamData.suffix, "")) changed = true;
+        if (p.updatePropertyFromConfig(p.teamData.customName, null)) changed = true;
         return changed;
     }
 
@@ -333,13 +338,14 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
         if (p.teamData.isDisabled() || p.teamData.vanishedFor.contains(viewer.getUniqueId())) return;
         if (!viewer.canSee(p) && p != viewer) return;
         TabComponent prefix = prefixCache.get(p.teamData.prefix.getFormat(viewer));
+        String displayName = p.teamData.customName != null ? p.teamData.customName.getFormat(viewer) : p.getNickname();
         viewer.getScoreboard().registerTeam(
                 p.teamData.teamName,
                 prefix,
                 suffixCache.get(p.teamData.suffix.getFormat(viewer)),
                 getTeamVisibility(p, viewer) ? NameVisibility.ALWAYS : NameVisibility.NEVER,
                 p.teamData.getCollisionRule() ? CollisionRule.ALWAYS : CollisionRule.NEVER,
-                Collections.singletonList(p.getNickname()),
+                Collections.singletonList(displayName),
                 teamOptions,
                 prefix.getLastStyle().toEnumChatFormat()
         );
@@ -465,7 +471,8 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
                     player.teamData.teamName,
                     player.teamData.prefix.get(),
                     player.teamData.suffix.get(),
-                    getTeamVisibility(player, player) ? NameVisibility.ALWAYS : NameVisibility.NEVER
+                    getTeamVisibility(player, player) ? NameVisibility.ALWAYS : NameVisibility.NEVER,
+                    player.teamData.customName != null ? player.teamData.customName.get() : null
             ));
         }
     }
@@ -499,7 +506,7 @@ public class NameTag extends RefreshableFeature implements NameTagManager, JoinL
                     suffixCache.get(player.getNametag().getSuffix()),
                     player.getNametag().getNameVisibility(),
                     Scoreboard.CollisionRule.ALWAYS,
-                    Collections.singletonList(player.getNickname()),
+                    Collections.singletonList(player.getNametag().getCustomName() != null ? player.getNametag().getCustomName() : player.getNickname()),
                     teamOptions,
                     prefix.getLastStyle().toEnumChatFormat()
             );

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTagPlayerData.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTagPlayerData.java
@@ -22,6 +22,9 @@ public class NameTagPlayerData {
     /** Player's tagsuffix */
     public Property suffix;
 
+    /** Player's custom nametag name */
+    public Property customName;
+
     /** Flag tracking whether this feature is disabled for the player with condition or not */
     public final AtomicBoolean disabled = new AtomicBoolean();
 

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTagProxyPlayerData.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTagProxyPlayerData.java
@@ -35,6 +35,7 @@ public class NameTagProxyPlayerData extends ProxyMessage {
     @NotNull private final String prefix;
     @NotNull private final String suffix;
     @NotNull private final Scoreboard.NameVisibility nameVisibility;
+    @Nullable private final String customName;
     @Nullable private String resolvedTeamName;
 
     /**
@@ -53,6 +54,7 @@ public class NameTagProxyPlayerData extends ProxyMessage {
         prefix = in.readUTF();
         suffix = in.readUTF();
         nameVisibility = Scoreboard.NameVisibility.getByName(in.readUTF());
+        customName = in.readBoolean() ? in.readUTF() : null;
     }
 
     @NotNull
@@ -68,6 +70,8 @@ public class NameTagProxyPlayerData extends ProxyMessage {
         out.writeUTF(prefix);
         out.writeUTF(suffix);
         out.writeUTF(nameVisibility.toString());
+        out.writeBoolean(customName != null);
+        if (customName != null) out.writeUTF(customName);
     }
 
     @Override
@@ -114,7 +118,7 @@ public class NameTagProxyPlayerData extends ProxyMessage {
                             suffix,
                             nameVisibility,
                             Scoreboard.CollisionRule.ALWAYS,
-                            Collections.singletonList(target.getNickname()),
+                            Collections.singletonList(customName != null ? customName : target.getNickname()),
                             feature.getTeamOptions(),
                             prefix.getLastStyle().toEnumChatFormat()
                     );

--- a/shared/src/main/resources/config/groups.yml
+++ b/shared/src/main/resources/config/groups.yml
@@ -10,6 +10,7 @@ _DEFAULT_:
   tabprefix: "%luckperms-prefix%"
   tagprefix: "%luckperms-prefix%"
   customtabname: "%player%"
+  customnametag: "%cmi_user_display_name%"
   tabsuffix: "%luckperms-suffix%"
   tagsuffix: "%luckperms-suffix%"
 


### PR DESCRIPTION
### About:
> But I’m facing an issue with the CMI plugin: if I use `customtabname: "%cmi_user_display_name%"`, everything shows correctly in the tab list — if the nickname is colored, it’s also colored. However, above players’ heads it doesn’t work, even if I don’t use `%cmi_user_glow_code%`. Which is very strange. I think the bug is either in TAB, or users should be allowed to change the `%player%` above the head to other placeholders as well.

### Summary
Adds `customnametag` to allow placeholder-based names in nametags, similar to `customtabname` for tablist.

### Problem
TAB used `player.getNickname()` for nametags, so placeholders like `%cmi_user_display_name%` didn’t work. Colors showed in tablist but not above players.

### Solution
- Added `customnametag` to `NameTagPlayerData.java`
- Updated `NameTag.java` to load/use `customnametag` instead of `player.getNickname()`
- Updated `NameTagProxyPlayerData.java` for proxy support
- Added `customnametag: "%cmi_user_display_name%"` to `groups.yml`

### Changes
1. **NameTagPlayerData.java**: Added `customName` property
2. **NameTag.java**:
   - `loadProperties()` loads `customnametag`
   - `updateProperties()` updates `customnametag`
   - `registerTeam()` uses `customName` when available
   - `refresh()` handles `customName` updates
3. **NameTagProxyPlayerData.java**: Added `customName` to proxy messages
4. **groups.yml**: Added `customnametag: "%cmi_user_display_name%"`

### Benefits
- Placeholders work in nametags
- Colors from `%cmi_user_display_name%` display above players
- Backward compatible
- Consistent with `customtabname`

### Testing
- Colors display in tablist and nametags
- `%cmi_user_glow_code%` works with custom names
- Proxy support works
- No regressions

### Usage
```yaml
_DEFAULT_:
  customnametag: "%cmi_user_display_name%"
```

This enables placeholder-based names with colors in nametags, resolving the issue where colors appeared in tablist but not above players.