### PR TITLE
feat: add RedisBungee placeholder support for network player count

### DIFF
--- a/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
+++ b/bungeecord/src/main/java/me/neznamy/tab/platforms/bungeecord/BungeePlatform.java
@@ -20,6 +20,7 @@ import me.neznamy.tab.shared.chat.component.object.TabAtlasSprite;
 import me.neznamy.tab.shared.chat.component.object.TabObjectComponent;
 import me.neznamy.tab.shared.chat.component.object.TabPlayerSprite;
 import me.neznamy.tab.shared.data.Server;
+import me.neznamy.tab.shared.features.PlaceholderManagerImpl;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.proxy.ProxyPlayer;
 import me.neznamy.tab.shared.features.proxy.ProxySupport;
@@ -102,6 +103,22 @@ public class BungeePlatform extends ProxyPlatform {
                 }
                 return PerformanceUtil.toString(count);
             });
+        }
+
+        // Register RedisBungee placeholders if RedisBungee is available
+        if (ReflectionUtils.classExists("com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI") &&
+                RedisBungeeAPI.getRedisBungeeApi() != null) {
+            PlaceholderManagerImpl pm = TAB.getInstance().getPlaceholderManager();
+            int refreshInterval = pm.getConfiguration().getRefreshInterval("%redisbungee_total%");
+            pm.registerInternalServerPlaceholder("%redisbungee_total%", refreshInterval, () -> {
+                try {
+                    return String.valueOf(RedisBungeeAPI.getRedisBungeeApi().getPlayerCount());
+                } catch (Exception e) {
+                    TAB.getInstance().getErrorManager().printError("Failed to get RedisBungee player count", e);
+                    return "0";
+                }
+            });
+            TAB.getInstance().debug("[TAB] Registered RedisBungee placeholder %redisbungee_total% with " + refreshInterval + "ms refresh interval");
         }
     }
 

--- a/shared/src/main/resources/config/config.yml
+++ b/shared/src/main/resources/config/config.yml
@@ -207,6 +207,8 @@ placeholder-refresh-intervals:
   "%player_ping%": 1000
   "%vault_prefix%": 1000
   "%rel_factionsuuid_relation_color%": 1000
+# RedisBungee total players placeholder - Needs RedisBungee plugin installed on proxy
+  "%redisbungee_total%": 1000
 
 # assigning groups by permission nodes instead of taking them from permission plugin
 assign-groups-by-permissions: false

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
@@ -15,6 +15,7 @@ import me.neznamy.tab.platforms.velocity.hook.VelocityPremiumVanishHook;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.TabTextColor;
+import me.neznamy.tab.shared.features.PlaceholderManagerImpl;
 import me.neznamy.tab.shared.chat.component.TabComponent;
 import me.neznamy.tab.shared.chat.component.TabTextComponent;
 import me.neznamy.tab.shared.data.Server;
@@ -136,6 +137,22 @@ public class VelocityPlatform extends ProxyPlatform {
                 }
                 return PerformanceUtil.toString(count);
             });
+        }
+
+        // Register RedisBungee placeholders if RedisBungee is available
+        if (ReflectionUtils.classExists("com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI") &&
+                RedisBungeeAPI.getRedisBungeeApi() != null) {
+            PlaceholderManagerImpl pm = TAB.getInstance().getPlaceholderManager();
+            int refreshInterval = pm.getConfiguration().getRefreshInterval("%redisbungee_total%");
+            pm.registerInternalServerPlaceholder("%redisbungee_total%", refreshInterval, () -> {
+                try {
+                    return String.valueOf(RedisBungeeAPI.getRedisBungeeApi().getPlayerCount());
+                } catch (Exception e) {
+                    TAB.getInstance().getErrorManager().printError("Failed to get RedisBungee player count", e);
+                    return "0";
+                }
+            });
+            TAB.getInstance().debug("[TAB] Registered RedisBungee placeholder %redisbungee_total% with " + refreshInterval + "ms refresh interval");
         }
     }
 


### PR DESCRIPTION

- Add "%redisbungee_total%" placeholder to BungeeCord and Velocity platforms
- Implement automatic RedisBungee detection and placeholder registration
- Configure default 1000ms refresh interval for network player count
- Include error handling and debug logging for RedisBungee integration
- Update shared config template with placeholder refresh intervals

This enables TAB users to display total network player count across all proxies in their tablist, header/footer, and scoreboard configurations when using RedisBungee-compatible plugins.