### PR TITLE
feat(scoreboard): add setLines method for dynamic line updates

### DIFF
--- a/api/src/main/java/me/neznamy/tab/api/scoreboard/Scoreboard.java
+++ b/api/src/main/java/me/neznamy/tab/api/scoreboard/Scoreboard.java
@@ -85,6 +85,22 @@ public interface Scoreboard {
     void removeLine(int index);
 
     /**
+     * Replaces all current lines with the provided list.
+     * Supports placeholders, which will automatically be refreshed.
+     * Client can only see up to 15 lines at a time.
+     * If the new list is identical to the current one, nothing happens.
+     *
+     * @param   lines
+     *          New list of lines to display
+     * @throws  NullPointerException
+     *          if {@code lines} is {@code null}
+     * @see     #getLines()
+     * @see     #addLine(String)
+     * @see     #removeLine(int)
+     */
+    void setLines(@NonNull List<String> lines);
+
+    /**
      * Unregisters this scoreboard from all players who can see it.
      */
     void unregister();

--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardImpl.java
@@ -285,6 +285,21 @@ public class ScoreboardImpl extends RefreshableFeature implements me.neznamy.tab
     }
 
     @Override
+    public void setLines(@NonNull List<String> newLines) {
+        ensureActive();
+        int commonSize = Math.min(this.lines.size(), newLines.size());
+        for (int i = 0; i < commonSize; i++) {
+            String newText = newLines.get(i) == null ? "" : newLines.get(i);
+            if (!this.lines.get(i).getText().equals(newText))
+                this.lines.get(i).setText(newText);
+        }
+        for (int i = this.lines.size() - 1; i >= commonSize; i--)
+            removeLine(i);
+        for (int i = commonSize; i < newLines.size(); i++)
+            addLine(newLines.get(i) == null ? "" : newLines.get(i));
+    }
+
+    @Override
     public void unregister() {
         ensureActive();
         for (TabPlayer all : players.toArray(new TabPlayer[0])) {


### PR DESCRIPTION
- Introduces a new method to replace all current scoreboard lines with a provided list.
- Prevents unnecessary updates if the new list is identical to the current one.