### PR TITLE
[Placeholders] Added locale of date-/time-format to config.yml

### DIFF
--- a/shared/src/main/resources/config/config.yml
+++ b/shared/src/main/resources/config/config.yml
@@ -183,6 +183,7 @@ placeholders:
   time-format: "[HH:mm:ss / h:mm a]"
   time-offset: 0
   register-tab-expansion: false
+  locale: en-US
 
 # https://github.com/NEZNAMY/TAB/wiki/Feature-guide:-Placeholder-output-replacements
 placeholder-output-replacements:


### PR DESCRIPTION
Greetings!

I was looking to use a `date-format` of `E dd.MM.yyyy` on our server when I noticed that the English locale was hard-coded - this little patch adds a config-option such that, for example, the name of the current day (`E`) can be adapted as needed.

I've tried to adhere to the existing style and hope to not have missed anything crucial - if so, please let me know and I'll get right to it. Thanks!