### PR TITLE
Register a custom <head_texture:url> MiniMessage

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/hook/MiniMessageHook.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/hook/MiniMessageHook.java
@@ -3,9 +3,18 @@ package me.neznamy.tab.shared.hook;
 import me.neznamy.tab.shared.chat.component.TabComponent;
 import me.neznamy.tab.shared.chat.hook.AdventureHook;
 import me.neznamy.tab.shared.TAB;
+import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.object.ObjectContents;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.regex.Pattern;
 
 /**
  * Class for hooking into MiniMessage to support its syntax.
@@ -16,13 +25,37 @@ public class MiniMessageHook {
     @Nullable
     private static final MiniMessage mm = createMiniMessage();
 
+    /** Pattern for validating minecraft texture URLs */
+    private static final Pattern TEXTURE_URL_PATTERN = Pattern.compile("^https?://textures\\.minecraft\\.net/texture/[0-9a-f]+$");
+
     @Nullable
     private static MiniMessage createMiniMessage() {
         try {
-            return MiniMessage.miniMessage();
+            return MiniMessage.builder()
+                    .editTags(builder -> builder.resolver(headTextureTag()))
+                    .build();
         } catch (Throwable ignored) {
             return null;
         }
+    }
+
+    private static TagResolver headTextureTag() {
+        return TagResolver.resolver("head_texture", (args, context) -> {
+            String textureUrl = args.popOr("Expected texture url").lowerValue().trim();
+            if (!TEXTURE_URL_PATTERN.matcher(textureUrl).matches()) {
+                throw context.newException("Expected a valid minecraft texture URL", args);
+            }
+
+            String json = String.format("{\"textures\":{\"SKIN\":{\"url\":\"%s\"}}}", textureUrl);
+            String texture = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+            PlayerHeadObjectContents contents = ObjectContents.playerHead()
+                    .profileProperty(
+                            PlayerHeadObjectContents.property("textures", texture)
+                    )
+                    .build();
+
+            return Tag.selfClosingInserting(Component.object(contents));
+        });
     }
 
     /**

--- a/shared/src/main/java/me/neznamy/tab/shared/hook/MiniMessageHook.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/hook/MiniMessageHook.java
@@ -1,32 +1,27 @@
 package me.neznamy.tab.shared.hook;
 
 import me.neznamy.tab.shared.chat.component.TabComponent;
+import me.neznamy.tab.shared.chat.component.object.TabObjectComponent;
 import me.neznamy.tab.shared.chat.hook.AdventureHook;
 import me.neznamy.tab.shared.TAB;
+import me.neznamy.tab.shared.util.ReflectionUtils;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.Tag;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
-import net.kyori.adventure.text.object.ObjectContents;
-import net.kyori.adventure.text.object.PlayerHeadObjectContents;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.regex.Pattern;
 
 /**
  * Class for hooking into MiniMessage to support its syntax.
  */
 public class MiniMessageHook {
 
+    private static final boolean OBJECT_COMPONENTS_AVAILABLE = ReflectionUtils.classExists("net.kyori.adventure.text.object.ObjectContents");
+
     /** Minimessage deserializer with disabled component post-processing */
     @Nullable
     private static final MiniMessage mm = createMiniMessage();
-
-    /** Pattern for validating minecraft texture URLs */
-    private static final Pattern TEXTURE_URL_PATTERN = Pattern.compile("^https?://textures\\.minecraft\\.net/texture/[0-9a-f]+$");
 
     @Nullable
     private static MiniMessage createMiniMessage() {
@@ -39,22 +34,14 @@ public class MiniMessageHook {
         }
     }
 
+    @NotNull
     private static TagResolver headTextureTag() {
+        if (OBJECT_COMPONENTS_AVAILABLE) {
+            return MiniMessageObjectHook.headTextureTag();
+        }
         return TagResolver.resolver("head_texture", (args, context) -> {
-            String textureUrl = args.popOr("Expected texture url").lowerValue().trim();
-            if (!TEXTURE_URL_PATTERN.matcher(textureUrl).matches()) {
-                throw context.newException("Expected a valid minecraft texture URL", args);
-            }
-
-            String json = String.format("{\"textures\":{\"SKIN\":{\"url\":\"%s\"}}}", textureUrl);
-            String texture = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
-            PlayerHeadObjectContents contents = ObjectContents.playerHead()
-                    .profileProperty(
-                            PlayerHeadObjectContents.property("textures", texture)
-                    )
-                    .build();
-
-            return Tag.selfClosingInserting(Component.object(contents));
+            args.popOr("Expected texture url"); // Consume the argument to keep the same tag signature
+            return Tag.selfClosingInserting(Component.text(TabObjectComponent.ERROR_MESSAGE));
         });
     }
 

--- a/shared/src/main/java/me/neznamy/tab/shared/hook/MiniMessageObjectHook.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/hook/MiniMessageObjectHook.java
@@ -1,0 +1,45 @@
+package me.neznamy.tab.shared.hook;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.tag.Tag;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.object.ObjectContents;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.regex.Pattern;
+
+/**
+ * Class for hooking into MiniMessage to support object components in a way that is compatible with older versions of the library.
+ */
+public class MiniMessageObjectHook {
+
+    /** Pattern for validating Minecraft texture URLs */
+    private static final Pattern TEXTURE_URL_PATTERN = Pattern.compile("^https?://textures\\.minecraft\\.net/texture/[0-9a-f]+$");
+
+    /**
+     * Creates a tag resolver for the "head_texture" tag, which allows inserting player heads with custom textures using a texture URL.
+     * The tag expects a single argument: the URL of the Minecraft texture. It validates the URL format and constructs the appropriate player head object if valid.
+     * If the URL is invalid, it throws an exception with a descriptive error message.
+     * @return A TagResolver for the "head_texture" tag.
+     */
+    public static TagResolver headTextureTag() {
+        return TagResolver.resolver("head_texture", (args, context) -> {
+            String textureUrl = args.popOr("Expected texture url").lowerValue().trim();
+            if (!TEXTURE_URL_PATTERN.matcher(textureUrl).matches()) {
+                throw context.newException("Expected a valid minecraft texture URL", args);
+            }
+
+            String json = String.format("{\"textures\":{\"SKIN\":{\"url\":\"%s\"}}}", textureUrl);
+            String texture = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+            PlayerHeadObjectContents contents = ObjectContents.playerHead()
+                    .profileProperty(
+                            PlayerHeadObjectContents.property("textures", texture)
+                    )
+                    .build();
+
+            return Tag.selfClosingInserting(Component.object(contents));
+        });
+    }
+
+}

--- a/shared/src/main/java/me/neznamy/tab/shared/hook/MiniMessageObjectHook.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/hook/MiniMessageObjectHook.java
@@ -14,21 +14,19 @@ import java.util.regex.Pattern;
  */
 public class MiniMessageObjectHook {
 
-    /** Pattern for validating Minecraft texture URLs */
-    private static final Pattern TEXTURE_URL_PATTERN = Pattern.compile("^https?://textures\\.minecraft\\.net/texture/[0-9a-f]+$");
+    /** Constant prefix shared by every Minecraft texture URL */
+    private static final String TEXTURE_URL_PREFIX = "https://textures.minecraft.net/texture/";
 
     /**
-     * Creates a tag resolver for the "head_texture" tag, which allows inserting player heads with custom textures using a texture URL.
-     * The tag expects a single argument: the URL of the Minecraft texture. It validates the URL format and constructs the appropriate player head object if valid.
-     * If the URL is invalid, it throws an exception with a descriptive error message.
+     * Creates a tag resolver for the "head_texture" tag, which allows inserting player heads with custom textures using a texture hash.
+     * The tag expects a single argument: the Minecraft texture hash (the part after "https://textures.minecraft.net/texture/").
+     *
      * @return A TagResolver for the "head_texture" tag.
      */
     public static TagResolver headTextureTag() {
         return TagResolver.resolver("head_texture", (args, context) -> {
-            String textureUrl = args.popOr("Expected texture url").lowerValue().trim();
-            if (!TEXTURE_URL_PATTERN.matcher(textureUrl).matches()) {
-                throw context.newException("Expected a valid minecraft texture URL", args);
-            }
+            String hash = args.popOr("Expected texture hash").lowerValue().trim();
+            String textureUrl = TEXTURE_URL_PREFIX + hash;
 
             String json = String.format("{\"textures\":{\"SKIN\":{\"url\":\"%s\"}}}", textureUrl);
             String texture = Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Register a custom <head_texture:url> MiniMessage tag that builds a player head object component from a Minecraft texture URL.