### PR TITLE
[Bukkit] Add compatibility with Canvas 26.1.2 (#1658)

### DIFF
--- a/bukkit/paper_1_21_11/src/main/java/me/neznamy/tab/platforms/bukkit/paper_1_21_11/CanvasPacketScoreboard.java
+++ b/bukkit/paper_1_21_11/src/main/java/me/neznamy/tab/platforms/bukkit/paper_1_21_11/CanvasPacketScoreboard.java
@@ -1,0 +1,63 @@
+package me.neznamy.tab.platforms.bukkit.paper_1_21_11;
+
+import lombok.NonNull;
+import me.neznamy.tab.platforms.bukkit.BukkitTabPlayer;
+import net.minecraft.network.chat.numbers.FixedFormat;
+import net.minecraft.network.protocol.game.ClientboundSetObjectivePacket;
+import net.minecraft.world.scores.criteria.ObjectiveCriteria;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Scoreboard override for Canvas (Folia fork) that implements scoreboards with
+ * new checks in NMS setters since 26.1.2.
+ */
+public class CanvasPacketScoreboard extends NMSPacketScoreboard {
+
+    /**
+     * Constructs new instance with given player.
+     *
+     * @param   player
+     *          Player this scoreboard will belong to
+     */
+    public CanvasPacketScoreboard(@NotNull BukkitTabPlayer player) {
+        super(player);
+    }
+
+    /**
+     * Updates the objective by creating a new one instead of updating the existing one,
+     * which would require sync access on Canvas.
+     *
+     * @param   objective
+     *          Objective to update
+     */
+    @Override
+    public void updateObjective(@NonNull Objective objective) {
+        net.minecraft.world.scores.Objective obj = new net.minecraft.world.scores.Objective(
+                dummyScoreboard,
+                objective.getName(),
+                ObjectiveCriteria.DUMMY,
+                objective.getTitle().convert(),
+                ObjectiveCriteria.RenderType.values()[objective.getHealthDisplay().ordinal()],
+                false,
+                objective.getNumberFormat() == null ? null : objective.getNumberFormat().toFixedFormat(FixedFormat::new)
+        );
+        objective.setPlatformObjective(obj);
+        sendPacket(new ClientboundSetObjectivePacket(obj, ObjectiveAction.UPDATE));
+    }
+
+    @Override
+    public void registerTeam(@NonNull Team team) {
+        player.getPlatform().runSyncGlobal(() -> super.registerTeam(team));
+    }
+
+    @Override
+    public void unregisterTeam(@NonNull Team team) {
+        // This one too, to avoid register+unregister causing unregister to run first
+        player.getPlatform().runSyncGlobal(() -> super.unregisterTeam(team));
+    }
+
+    @Override
+    public void updateTeam(@NonNull Team team) {
+        player.getPlatform().runSyncGlobal(() -> super.updateTeam(team));
+    }
+}

--- a/bukkit/paper_1_21_11/src/main/java/me/neznamy/tab/platforms/bukkit/paper_1_21_11/NMSImplementationProvider.java
+++ b/bukkit/paper_1_21_11/src/main/java/me/neznamy/tab/platforms/bukkit/paper_1_21_11/NMSImplementationProvider.java
@@ -8,15 +8,19 @@ import me.neznamy.tab.platforms.bukkit.provider.ImplementationProvider;
 import me.neznamy.tab.shared.platform.Scoreboard;
 import me.neznamy.tab.shared.platform.TabList;
 import me.neznamy.tab.shared.platform.TabListEntryTracker;
+import me.neznamy.tab.shared.util.ReflectionUtils;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Implementation provider using direct Mojang-mapped NMS code for paper 1.21.11.
+ * Implementation provider using direct Mojang-mapped NMS code for Paper 1.21.11 - 26.1.2.
  */
 @Getter
 public class NMSImplementationProvider implements ImplementationProvider {
+
+    /** Flag tracking if this server is Canvas 26.1.2+ with new scoreboard checks */
+    private final boolean isCanvas = ReflectionUtils.classExists("io.canvasmc.canvas.world.scores.TeamData");
 
     @NotNull
     private final ComponentConverter<?> componentConverter = new NMSComponentConverter();
@@ -24,7 +28,11 @@ public class NMSImplementationProvider implements ImplementationProvider {
     @Override
     @NotNull
     public Scoreboard newScoreboard(@NotNull BukkitTabPlayer player) {
-        return new NMSPacketScoreboard(player);
+        if (isCanvas) {
+            return new CanvasPacketScoreboard(player);
+        } else {
+            return new NMSPacketScoreboard(player);
+        }
     }
 
     @Override

--- a/bukkit/paper_1_21_11/src/main/java/me/neznamy/tab/platforms/bukkit/paper_1_21_11/NMSPacketScoreboard.java
+++ b/bukkit/paper_1_21_11/src/main/java/me/neznamy/tab/platforms/bukkit/paper_1_21_11/NMSPacketScoreboard.java
@@ -30,7 +30,7 @@ public class NMSPacketScoreboard extends SafeScoreboard<BukkitTabPlayer> {
     private static final ChatFormatting[] formats = ChatFormatting.values();
     private static final net.minecraft.world.scores.Team.CollisionRule[] collisions = net.minecraft.world.scores.Team.CollisionRule.values();
     private static final net.minecraft.world.scores.Team.Visibility[] visibilities = net.minecraft.world.scores.Team.Visibility.values();
-    private static final Scoreboard dummyScoreboard = new Scoreboard();
+    protected static final Scoreboard dummyScoreboard = new Scoreboard();
     private static final Field players = ReflectionUtils.getOnlyField(ClientboundSetPlayerTeamPacket.class, Collection.class);
 
     /**
@@ -170,7 +170,7 @@ public class NMSPacketScoreboard extends SafeScoreboard<BukkitTabPlayer> {
      * @param   packet
      *          Packet to send
      */
-    private void sendPacket(@NotNull Packet<?> packet) {
+    protected void sendPacket(@NotNull Packet<?> packet) {
         ((CraftPlayer)player.getPlayer()).getHandle().connection.send(packet);
     }
 }

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
@@ -371,11 +371,21 @@ public class BukkitPlatform implements BackendPlatform {
      * Runs task in the main thread for given entity.
      *
      * @param   entity
-     *          Entity's main thread
+     *          Entity to run the task for
      * @param   task
      *          Task to run
      */
     public void runSync(@NotNull Entity entity, @NotNull Runnable task) {
+        Bukkit.getScheduler().runTask(plugin, task);
+    }
+
+    /**
+     * Runs task in the global tick thread.
+     *
+     * @param   task
+     *          Task to run
+     */
+    public void runSyncGlobal(@NotNull Runnable task) {
         Bukkit.getScheduler().runTask(plugin, task);
     }
 

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/FoliaPlatform.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/FoliaPlatform.java
@@ -18,6 +18,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 
+import java.lang.reflect.Method;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.function.Consumer;
@@ -28,14 +29,25 @@ import java.util.function.Function;
  */
 public class FoliaPlatform extends BukkitPlatform {
 
+    /** Global tick thread scheduler */
+    @NotNull
+    private final Object globalScheduler;
+
+    /** FoliaGlobalRegionScheduler#execute(Plugin, Runnable) method */
+    private final Method globalScheduler_execute;
+
     /**
      * Constructs new instance with given plugin.
      *
      * @param   plugin
      *          Plugin
      */
+    @SneakyThrows
+    @SuppressWarnings("JavaReflectionMemberAccess")
     public FoliaPlatform(@NotNull JavaPlugin plugin) {
         super(plugin);
+        globalScheduler = Bukkit.class.getMethod("getGlobalRegionScheduler").invoke(null);
+        globalScheduler_execute = globalScheduler.getClass().getMethod("execute", Plugin.class, Runnable.class);
     }
 
     @Override
@@ -142,5 +154,19 @@ public class FoliaPlatform extends BukkitPlatform {
         Consumer<?> consumer = $ -> task.run(); // Reflection and lambdas don't go together
         entityScheduler.getClass().getMethod("run", Plugin.class, Consumer.class, Runnable.class)
                 .invoke(entityScheduler, getPlugin(), consumer, null);
+    }
+
+    /**
+     * Runs task in global tick thread. It's using reflection, because
+     * Folia uses Java 17 while TAB maintains Java 8 compatibility for compatibility
+     * with MC versions older than their player base.
+     *
+     * @param   task
+     *          Task to run
+     */
+    @Override
+    @SneakyThrows
+    public void runSyncGlobal(@NotNull Runnable task) {
+        globalScheduler_execute.invoke(globalScheduler, getPlugin(), task);
     }
 }


### PR DESCRIPTION
The PR #1659 uses reflection to modify **final** team packet fields, which goes directly against #1648.

This PR implements #1658 by using Folia's global region scheduler for team operations. Objective update is done by re-creating the objective, which isn't limited by a thread check.