### PR TITLE
Add opaque nametag visibility mode

### DIFF
--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/BukkitPlatform.java
@@ -389,6 +389,11 @@ public class BukkitPlatform implements BackendPlatform {
         Bukkit.getScheduler().runTask(plugin, task);
     }
 
+    @Override
+    public boolean hasLineOfSight(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        return ((Player) viewer.getPlayer()).hasLineOfSight((Player) target.getPlayer());
+    }
+
     /**
      * Converts component to string using bukkit RGB format if supported by the server.
      * If not, closest legacy color is used instead.

--- a/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/FoliaPlatform.java
+++ b/bukkit/src/main/java/me/neznamy/tab/platforms/bukkit/platform/FoliaPlatform.java
@@ -171,4 +171,9 @@ public class FoliaPlatform extends BukkitPlatform {
         if (!getPlugin().isEnabled()) return; // Server shutdown, no one cares anymore, everyone is about to be kicked
         globalScheduler_execute.invoke(globalScheduler, getPlugin(), task);
     }
+
+    @Override
+    public boolean hasLineOfSight(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        return true; // Cross-entity line-of-sight checks are not safe from Folia's global scheduler.
+    }
 }

--- a/fabric/src/main/java/me/neznamy/tab/platforms/fabric/FabricPlatform.java
+++ b/fabric/src/main/java/me/neznamy/tab/platforms/fabric/FabricPlatform.java
@@ -274,6 +274,16 @@ public record FabricPlatform(MinecraftServer server) implements BackendPlatform 
     }
 
     @Override
+    public void runSyncGlobal(@NotNull Runnable task) {
+        server.execute(task);
+    }
+
+    @Override
+    public boolean hasLineOfSight(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        return ((FabricTabPlayer) viewer).getPlayer().hasLineOfSight(((FabricTabPlayer) target).getPlayer());
+    }
+
+    @Override
     @NotNull
     public Object dump() {
         Map<String, Object> map = new LinkedHashMap<>();

--- a/forge/src/main/java/me/neznamy/tab/platforms/forge/ForgePlatform.java
+++ b/forge/src/main/java/me/neznamy/tab/platforms/forge/ForgePlatform.java
@@ -263,6 +263,16 @@ public record ForgePlatform(MinecraftServer server) implements BackendPlatform {
     }
 
     @Override
+    public void runSyncGlobal(@NotNull Runnable task) {
+        server.execute(task);
+    }
+
+    @Override
+    public boolean hasLineOfSight(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        return ((ForgeTabPlayer) viewer).getPlayer().hasLineOfSight(((ForgeTabPlayer) target).getPlayer());
+    }
+
+    @Override
     @NotNull
     public Object dump() {
         Map<String, Object> map = new LinkedHashMap<>();

--- a/neoforge/src/main/java/me/neznamy/tab/platforms/neoforge/NeoForgePlatform.java
+++ b/neoforge/src/main/java/me/neznamy/tab/platforms/neoforge/NeoForgePlatform.java
@@ -254,6 +254,16 @@ public record NeoForgePlatform(MinecraftServer server) implements BackendPlatfor
     }
 
     @Override
+    public void runSyncGlobal(@NotNull Runnable task) {
+        server.execute(task);
+    }
+
+    @Override
+    public boolean hasLineOfSight(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        return ((NeoForgeTabPlayer) viewer).getPlayer().hasLineOfSight(((NeoForgeTabPlayer) target).getPlayer());
+    }
+
+    @Override
     @NotNull
     public Object dump() {
         Map<String, Object> map = new LinkedHashMap<>();

--- a/shared/src/main/java/me/neznamy/tab/shared/command/NameTagCommand.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/command/NameTagCommand.java
@@ -16,10 +16,14 @@ import java.util.Locale;
 /**
  * Handler for "/tab nametag" subcommand.
  * Options:
- *   /tab nametag show/hide/toggle [player] [viewer] [-s]
- *   /tab nametag showview/hideview/toggleview [viewer] [-s]
+ *   /tab nametag show/opaque/hide/toggle [player] [viewer] [-s]
+ *   /tab nametag showview/opaqueview/hideview/toggleview [viewer] [-s]
  */
 public class NameTagCommand extends SubCommand {
+
+    private static final List<String> TARGET_ACTIONS = Arrays.asList("show", "opaque", "hide", "toggle");
+    private static final List<String> VIEW_ACTIONS = Arrays.asList("showview", "opaqueview", "hideview", "toggleview");
+    private static final List<String> ALL_ACTIONS = Arrays.asList("show", "opaque", "hide", "toggle", "showview", "opaqueview", "hideview", "toggleview");
 
     /**
      * Constructs new instance
@@ -47,9 +51,9 @@ public class NameTagCommand extends SubCommand {
         }
 
         String action = args[0].toLowerCase(Locale.US);
-        if (action.equals("show") || action.equals("hide") || action.equals("toggle")) {
+        if (TARGET_ACTIONS.contains(action)) {
             processTarget(teams, sender, action, Arrays.copyOfRange(args, 1, args.length));
-        } else if (action.equals("showview") || action.equals("hideview") || action.equals("toggleview")) {
+        } else if (VIEW_ACTIONS.contains(action)) {
             processView(teams, sender, action,  Arrays.copyOfRange(args, 1, args.length));
         } else {
             sendMessages(sender, getMessages().getNameTagHelpMenu());
@@ -58,14 +62,19 @@ public class NameTagCommand extends SubCommand {
 
     private void processTarget(@NotNull NameTag teams, @Nullable TabPlayer sender, @NotNull String action, @NotNull String[] args) {
         boolean silent = args.length > 0 && args[args.length - 1].equals("-s");
+        String[] effectiveArgs = silent ? Arrays.copyOf(args, args.length - 1) : args;
 
-        TabPlayer player = args.length >= 1 ? TAB.getInstance().getPlayer(args[0]) : sender;
+        TabPlayer player = effectiveArgs.length >= 1 ? TAB.getInstance().getPlayer(effectiveArgs[0]) : sender;
         if (player == null) {
-            sendMessage(sender, getMessages().getPlayerNotFound(args[0]));
+            sendMessage(sender, effectiveArgs.length == 0 ? getMessages().getNameTagNoArgFromConsole() : getMessages().getPlayerNotFound(effectiveArgs[0]));
             return;
         }
 
-        TabPlayer viewer = args.length >= 2 ? TAB.getInstance().getPlayer(args[1]) : null;
+        TabPlayer viewer = effectiveArgs.length >= 2 ? TAB.getInstance().getPlayer(effectiveArgs[1]) : null;
+        if (effectiveArgs.length >= 2 && viewer == null) {
+            sendMessage(sender, getMessages().getPlayerNotFound(effectiveArgs[1]));
+            return;
+        }
 
         String permission = sender == viewer ? TabConstants.Permission.COMMAND_NAMETAG_VISIBILITY : TabConstants.Permission.COMMAND_NAMETAG_VISIBILITY_OTHER;
         if (!hasPermission(sender, permission)) {
@@ -73,7 +82,13 @@ public class NameTagCommand extends SubCommand {
             return;
         }
 
-        if (action.equals("show")) {
+        if (action.equals("opaque")) {
+            if (viewer != null) {
+                teams.getVisibilityManager().setOpaqueNameTag(player, viewer, "Processing command (opaque)", !silent);
+            } else {
+                teams.getVisibilityManager().setOpaqueNameTag(player, null, "Processing command (opaque)", !silent);
+            }
+        } else if (action.equals("show")) {
             if (viewer != null) {
                 teams.getVisibilityManager().showNameTag(player, viewer, NameTagInvisibilityReason.HIDE_COMMAND, "Processing command (show)", !silent);
             } else {
@@ -96,10 +111,11 @@ public class NameTagCommand extends SubCommand {
 
     private void processView(@NotNull NameTag teams, @Nullable TabPlayer sender, @NotNull String action, @NotNull String[] args) {
         boolean silent = args.length > 0 && args[args.length - 1].equals("-s");
-        TabPlayer viewer = args.length >= 1 ? TAB.getInstance().getPlayer(args[0]) : sender;
+        String[] effectiveArgs = silent ? Arrays.copyOf(args, args.length - 1) : args;
+        TabPlayer viewer = effectiveArgs.length >= 1 ? TAB.getInstance().getPlayer(effectiveArgs[0]) : sender;
 
         if (viewer == null) {
-            sendMessage(sender, getMessages().getPlayerNotFound(args[0]));
+            sendMessage(sender, effectiveArgs.length == 0 ? getMessages().getNameTagNoArgFromConsole() : getMessages().getPlayerNotFound(effectiveArgs[0]));
             return;
         }
 
@@ -111,24 +127,29 @@ public class NameTagCommand extends SubCommand {
 
         if (action.equals("showview")) {
             teams.showNameTagVisibilityView(viewer, !silent);
+            teams.getVisibilityManager().clearOpaqueNameTagView(viewer, "Processing command (showview)");
+        } else if (action.equals("opaqueview")) {
+            teams.getVisibilityManager().setOpaqueNameTagView(viewer, "Processing command (opaqueview)", !silent);
         } else if (action.equals("hideview")) {
             teams.hideNameTagVisibilityView(viewer, !silent);
+            teams.getVisibilityManager().clearOpaqueNameTagView(viewer, "Processing command (hideview)");
         } else {
             teams.toggleNameTagVisibilityView(viewer, !silent);
+            teams.getVisibilityManager().clearOpaqueNameTagView(viewer, "Processing command (toggleview)");
         }
     }
 
     @Override
     @NotNull
     public List<String> complete(@Nullable TabPlayer sender, @NotNull String[] arguments) {
-        if (arguments.length == 1) return getStartingArgument(Arrays.asList("show", "hide", "toggle", "showview", "hideview", "toggleview"), arguments[0]);
+        if (arguments.length == 1) return getStartingArgument(ALL_ACTIONS, arguments[0]);
         if (arguments.length == 2) return getOnlinePlayers(arguments[1]);
         String action = arguments[0].toLowerCase(Locale.US);
-        boolean targeting = action.equals("show") || action.equals("hide") || action.equals("toggle");
+        boolean targeting = TARGET_ACTIONS.contains(action);
         if (arguments.length == 3) {
             if (targeting) {
                 return getOnlinePlayers(arguments[2]);
-            } else if (action.equals("showview") || action.equals("hideview") || action.equals("toggleview")) {
+            } else if (VIEW_ACTIONS.contains(action)) {
                 return getStartingArgument(Collections.singletonList("-s"), arguments[2]);
             } else {
                 return Collections.emptyList();

--- a/shared/src/main/java/me/neznamy/tab/shared/config/MessageFile.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/MessageFile.java
@@ -75,8 +75,8 @@ public class MessageFile extends YamlConfigurationFile {
     // ------------------
 
     private final List<String> nameTagHelpMenu = getStringList("nametag.help-menu", Arrays.asList(
-            "/tab nametag <show/hide/toggle> [player] [-s] - Toggles nametag of specified player",
-            "/tab nametag <showview/hideview/toggleview> [player] [viewer] [-s] - Toggles nametag VIEW of specified player on other player(s)"
+            "/tab nametag <show/opaque/hide/toggle> [player] [viewer] [-s] - Toggles nametag of specified player",
+            "/tab nametag <showview/opaqueview/hideview/toggleview> [viewer] [-s] - Toggles nametag VIEW of specified player"
     ));
     private final String nameTagFeatureNotEnabled = getString("nametag.feature-not-enabled", "&cThis command requires nametag feature to be enabled.");
     private final String nameTagViewHidden = getString("nametag.view-hidden", "&aNametags of all players were hidden to you");

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTagInvisibilityReason.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTagInvisibilityReason.java
@@ -12,5 +12,8 @@ public enum NameTagInvisibilityReason {
     MEETING_CONFIGURED_CONDITION,
 
     /** /tab nametag hide command */
-    HIDE_COMMAND
+    HIDE_COMMAND,
+
+    /** /tab nametag opaque command hides nametag from viewers without line of sight */
+    OPAQUE_OCCLUSION
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTagPlayerData.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/NameTagPlayerData.java
@@ -42,6 +42,12 @@ public class NameTagPlayerData {
     /** Flag tracking whether this player disabled nametags on all players or not */
     public boolean invisibleNameTagView;
 
+    /** Whether opaque nametag mode is enabled for all viewers */
+    private boolean opaqueNameTagMode;
+
+    /** Viewers with opaque nametag mode enabled only for them */
+    private final Set<TabPlayer> opaqueNameTagViewers = Collections.newSetFromMap(new WeakHashMap<>());
+
     /** Players who this player is vanished for */
     public final Set<UUID> vanishedFor = new HashSet<>();
 
@@ -199,6 +205,45 @@ public class NameTagPlayerData {
         if (viewer.teamData.invisibleNameTagView) return false; // Viewer does not want to see nametags
         if (viewer.getVersion() == ProtocolVersion.V1_8 && player.hasInvisibilityPotion()) return false;
         return true;
+    }
+
+    /**
+     * Returns {@code true} if opaque nametag mode is enabled for specified viewer.
+     *
+     * @param   viewer
+     *          Viewer to check
+     * @return  {@code true} if enabled, {@code false} if not
+     */
+    public boolean isOpaqueNameTagMode(@NotNull TabPlayer viewer) {
+        return opaqueNameTagMode || opaqueNameTagViewers.contains(viewer);
+    }
+
+    /**
+     * Enables or disables opaque nametag mode globally or for specified viewer.
+     *
+     * @param   viewer
+     *          Viewer to change mode for, or {@code null} for all viewers
+     * @param   enabled
+     *          Whether opaque nametag mode should be enabled
+     */
+    public void setOpaqueNameTagMode(@Nullable TabPlayer viewer, boolean enabled) {
+        if (viewer == null) {
+            opaqueNameTagMode = enabled;
+            if (!enabled) opaqueNameTagViewers.clear();
+        } else if (enabled) {
+            opaqueNameTagViewers.add(viewer);
+        } else {
+            opaqueNameTagViewers.remove(viewer);
+        }
+    }
+
+    /**
+     * Returns {@code true} if opaque nametag mode is enabled globally or for at least one viewer.
+     *
+     * @return  {@code true} if enabled, {@code false} if not
+     */
+    public boolean hasOpaqueNameTagMode() {
+        return opaqueNameTagMode || !opaqueNameTagViewers.isEmpty();
     }
 
     public void registerTeam(@NotNull TabPlayer target, @NotNull String teamName, @NotNull TabComponent prefix, @NotNull TabComponent suffix,

--- a/shared/src/main/java/me/neznamy/tab/shared/features/nametags/VisibilityManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/nametags/VisibilityManager.java
@@ -14,6 +14,13 @@ import me.neznamy.tab.shared.placeholders.conditions.Condition;
 import me.neznamy.tab.shared.platform.Scoreboard;
 import me.neznamy.tab.shared.platform.TabPlayer;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 /**
  * Sub-feature for NameTag feature that manages nametag visibility.
@@ -27,6 +34,10 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
     @Getter
     @NotNull
     private final Condition invisibleCondition;
+
+    /** Viewers using opaque nametag view for all players */
+    @NotNull
+    private final Set<TabPlayer> opaqueNameTagViewers = Collections.newSetFromMap(new WeakHashMap<>());
 
     /**
      * Constructs new instance.
@@ -58,6 +69,8 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
         for (TabPlayer all : nameTags.getOnlinePlayers().getPlayers()) {
             onJoin(all);
         }
+        getCustomThread().repeatTask(new TimedCaughtTask(TAB.getInstance().getCpu(),
+                this::requestOpaqueOcclusionRefresh, getFeatureName(), "Updating opaque nametag occlusion"), 250);
     }
 
     @Override
@@ -66,6 +79,7 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
             connectedPlayer.teamData.hideNametag(NameTagInvisibilityReason.MEETING_CONFIGURED_CONDITION);
             updateVisibility(connectedPlayer);
         }
+        if (!opaqueNameTagViewers.isEmpty()) requestOpaqueOcclusionRefresh();
     }
 
     @NotNull
@@ -132,6 +146,7 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
                             boolean sendMessage) {
         ensureActive();
         getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            clearOpaqueNameTagMode(player, null);
             if (player.teamData.hideNametag(reason)) {
                 updateVisibility(player);
             }
@@ -143,6 +158,7 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
                             @NonNull String cpuReason, boolean sendMessage) {
         ensureActive();
         getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            clearOpaqueNameTagMode(player, viewer);
             if (player.teamData.hideNametag(viewer, reason)) {
                 updateVisibility(player, viewer);
             }
@@ -154,6 +170,7 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
                             boolean sendMessage) {
         ensureActive();
         getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            clearOpaqueNameTagMode(player, null);
             if (player.teamData.showNametag(reason)) {
                 updateVisibility(player);
             }
@@ -165,6 +182,7 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
                             @NonNull String cpuReason, boolean sendMessage) {
         ensureActive();
         getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            clearOpaqueNameTagMode(player, viewer);
             if (player.teamData.showNametag(viewer, reason)) {
                 updateVisibility(player, viewer);
             }
@@ -176,6 +194,7 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
                               boolean sendMessage) {
         ensureActive();
         getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            clearOpaqueNameTagMode(player, null);
             if (player.teamData.hasHiddenNametag(reason)) {
                 player.teamData.showNametag(reason);
                 if (sendMessage) player.sendMessage(TAB.getInstance().getConfiguration().getMessages().getNameTagTargetShown());
@@ -191,6 +210,7 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
                               @NonNull String cpuReason, boolean sendMessage) {
         ensureActive();
         getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            clearOpaqueNameTagMode(player, viewer);
             if (player.teamData.hasHiddenNametag(viewer, reason)) {
                 player.teamData.showNametag(viewer, reason);
                 if (sendMessage) player.sendMessage(TAB.getInstance().getConfiguration().getMessages().getNameTagTargetShown());
@@ -200,5 +220,149 @@ public class VisibilityManager extends RefreshableFeature implements JoinListene
             }
             updateVisibility(player, viewer);
         }, getFeatureName(), cpuReason));
+    }
+
+    public void setOpaqueNameTag(@NonNull TabPlayer player, @Nullable TabPlayer viewer, @NonNull String cpuReason,
+                                 boolean sendMessage) {
+        ensureActive();
+        getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            player.teamData.setOpaqueNameTagMode(viewer, true);
+            if (viewer != null) {
+                player.teamData.showNametag(viewer, NameTagInvisibilityReason.HIDE_COMMAND);
+                player.teamData.showNametag(viewer, NameTagInvisibilityReason.OPAQUE_OCCLUSION);
+                updateVisibility(player, viewer);
+            } else {
+                player.teamData.showNametag(NameTagInvisibilityReason.HIDE_COMMAND);
+                for (TabPlayer currentViewer : nameTags.getOnlinePlayers().getPlayers()) {
+                    player.teamData.showNametag(currentViewer, NameTagInvisibilityReason.OPAQUE_OCCLUSION);
+                }
+                updateVisibility(player);
+            }
+            requestOpaqueOcclusionRefresh();
+            if (sendMessage) player.sendMessage(TAB.getInstance().getConfiguration().getMessages().getNameTagTargetShown());
+        }, getFeatureName(), cpuReason));
+    }
+
+    public void setOpaqueNameTagView(@NonNull TabPlayer viewer, @NonNull String cpuReason, boolean sendMessage) {
+        ensureActive();
+        getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            viewer.teamData.invisibleNameTagView = false;
+            viewer.expansionData.setNameTagVisibility(true);
+            opaqueNameTagViewers.add(viewer);
+            for (TabPlayer player : nameTags.getOnlinePlayers().getPlayers()) {
+                player.teamData.showNametag(viewer, NameTagInvisibilityReason.OPAQUE_OCCLUSION);
+                updateVisibility(player, viewer);
+            }
+            requestOpaqueOcclusionRefresh();
+            if (sendMessage) viewer.sendMessage(TAB.getInstance().getConfiguration().getMessages().getNameTagViewShown());
+        }, getFeatureName(), cpuReason));
+    }
+
+    public void clearOpaqueNameTagView(@NonNull TabPlayer viewer, @NonNull String cpuReason) {
+        ensureActive();
+        getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            opaqueNameTagViewers.remove(viewer);
+            for (TabPlayer player : nameTags.getOnlinePlayers().getPlayers()) {
+                if (!isOpaqueNameTagMode(player, viewer) && player.teamData.showNametag(viewer, NameTagInvisibilityReason.OPAQUE_OCCLUSION)) {
+                    updateVisibility(player, viewer);
+                }
+            }
+        }, getFeatureName(), cpuReason));
+    }
+
+    private void requestOpaqueOcclusionRefresh() {
+        List<OpaqueVisibilityCheck> checks = new ArrayList<>();
+        for (TabPlayer player : nameTags.getOnlinePlayers().getPlayers()) {
+            if (!hasOpaqueNameTagMode(player) || player.teamData.isDisabled()) continue;
+            for (TabPlayer viewer : nameTags.getOnlinePlayers().getPlayers()) {
+                checks.add(new OpaqueVisibilityCheck(player, viewer, !isOpaqueNameTagMode(player, viewer)));
+            }
+        }
+        if (checks.isEmpty()) return;
+        TAB.getInstance().getPlatform().runSyncGlobal(() -> {
+            List<OpaqueVisibilityResult> results = new ArrayList<>(checks.size());
+            for (OpaqueVisibilityCheck check : checks) {
+                if (!check.player.isOnline() || !check.viewer.isOnline()) {
+                    results.add(new OpaqueVisibilityResult(check.player, check.viewer, true));
+                    continue;
+                }
+                results.add(new OpaqueVisibilityResult(check.player, check.viewer,
+                        check.forceVisible || check.viewer == check.player || hasLineOfSight(check.viewer, check.player)));
+            }
+            getCustomThread().execute(new TimedCaughtTask(TAB.getInstance().getCpu(),
+                    () -> applyOpaqueOcclusionResults(results), getFeatureName(), "Applying opaque nametag occlusion"));
+        });
+    }
+
+    private void applyOpaqueOcclusionResults(@NonNull List<OpaqueVisibilityResult> results) {
+        for (OpaqueVisibilityResult result : results) {
+            if (!nameTags.getOnlinePlayers().contains(result.player) || !nameTags.getOnlinePlayers().contains(result.viewer)) continue;
+            boolean visible = result.visible;
+            if (!hasOpaqueNameTagMode(result.player) || result.player.teamData.isDisabled()) {
+                visible = true;
+            } else if (!isOpaqueNameTagMode(result.player, result.viewer)) {
+                visible = true;
+            }
+            boolean changed = visible
+                    ? result.player.teamData.showNametag(result.viewer, NameTagInvisibilityReason.OPAQUE_OCCLUSION)
+                    : result.player.teamData.hideNametag(result.viewer, NameTagInvisibilityReason.OPAQUE_OCCLUSION);
+            if (changed) updateVisibility(result.player, result.viewer);
+        }
+    }
+
+    private void clearOpaqueNameTagMode(@NonNull TabPlayer player, @Nullable TabPlayer viewer) {
+        player.teamData.setOpaqueNameTagMode(viewer, false);
+        if (viewer != null) {
+            if (!isOpaqueNameTagMode(player, viewer) && player.teamData.showNametag(viewer, NameTagInvisibilityReason.OPAQUE_OCCLUSION)) {
+                updateVisibility(player, viewer);
+            }
+        } else {
+            for (TabPlayer currentViewer : nameTags.getOnlinePlayers().getPlayers()) {
+                if (!isOpaqueNameTagMode(player, currentViewer) && player.teamData.showNametag(currentViewer, NameTagInvisibilityReason.OPAQUE_OCCLUSION)) {
+                    updateVisibility(player, currentViewer);
+                }
+            }
+        }
+    }
+
+    private boolean hasOpaqueNameTagMode(@NonNull TabPlayer player) {
+        return player.teamData.hasOpaqueNameTagMode() || !opaqueNameTagViewers.isEmpty();
+    }
+
+    private boolean isOpaqueNameTagMode(@NonNull TabPlayer player, @NonNull TabPlayer viewer) {
+        return player.teamData.isOpaqueNameTagMode(viewer) || opaqueNameTagViewers.contains(viewer);
+    }
+
+    private boolean hasLineOfSight(@NonNull TabPlayer viewer, @NonNull TabPlayer target) {
+        if (!viewer.server.canSee(target.server)) return false;
+        if (viewer.world != target.world) return false;
+        if (!viewer.canSee(target)) return false;
+        return TAB.getInstance().getPlatform().hasLineOfSight(viewer, target);
+    }
+
+    private static class OpaqueVisibilityCheck {
+
+        @NotNull private final TabPlayer player;
+        @NotNull private final TabPlayer viewer;
+        private final boolean forceVisible;
+
+        private OpaqueVisibilityCheck(@NotNull TabPlayer player, @NotNull TabPlayer viewer, boolean forceVisible) {
+            this.player = player;
+            this.viewer = viewer;
+            this.forceVisible = forceVisible;
+        }
+    }
+
+    private static class OpaqueVisibilityResult {
+
+        @NotNull private final TabPlayer player;
+        @NotNull private final TabPlayer viewer;
+        private final boolean visible;
+
+        private OpaqueVisibilityResult(@NotNull TabPlayer player, @NotNull TabPlayer viewer, boolean visible) {
+            this.player = player;
+            this.viewer = viewer;
+            this.visible = visible;
+        }
     }
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/platform/Platform.java
@@ -251,4 +251,30 @@ public interface Platform {
      */
     @NotNull
     Object dump();
+
+    /**
+     * Runs task in the global server thread when the platform requires it.
+     * Platforms without a server thread requirement can run the task directly.
+     *
+     * @param   task
+     *          Task to run
+     */
+    default void runSyncGlobal(@NotNull Runnable task) {
+        task.run();
+    }
+
+    /**
+     * Returns {@code true} if the viewer has a clear line of sight to target.
+     * Platforms that cannot calculate block occlusion should return {@code true}
+     * after regular visibility checks are satisfied.
+     *
+     * @param   viewer
+     *          Viewer
+     * @param   target
+     *          Target being viewed
+     * @return  {@code true} if line of sight is clear, {@code false} if blocked
+     */
+    default boolean hasLineOfSight(@NotNull TabPlayer viewer, @NotNull TabPlayer target) {
+        return true;
+    }
 }

--- a/shared/src/main/resources/config/messages.yml
+++ b/shared/src/main/resources/config/messages.yml
@@ -62,8 +62,8 @@ bossbar-help-menu:
   - "/tab bossbar announce <name> <length>"
 nametag:
   help-menu:
-    - "/tab nametag <show/hide/toggle> [player] [-s] - Toggles nametag of specified player"
-    - "/tab nametag <showview/hideview/toggleview> [player] [viewer] [-s] - Toggles nametag VIEW of specified player on other player(s)"
+    - "/tab nametag <show/opaque/hide/toggle> [player] [viewer] [-s] - Toggles nametag of specified player"
+    - "/tab nametag <showview/opaqueview/hideview/toggleview> [viewer] [-s] - Toggles nametag VIEW of specified player"
   feature-not-enabled: "&cThis command requires nametag feature to be enabled."
   view-hidden: "&aNametags of all players were hidden to you"
   view-shown: "&aNametags of all players were shown to you"


### PR DESCRIPTION
# Add opaque nametag visibility mode

## Summary

This pull request adds an additional nametag visibility mode for TAB:

- `/tab nametag opaque`
- `/tab nametag opaqueview`

The new mode keeps using Minecraft's existing scoreboard team nametag system. It does not introduce `text_display`, armor stands, or any custom floating nametag entities.

The goal is to allow nametags to stay visible normally, while preventing players from seeing nametags through blocks.

## Why

TAB currently supports showing and hiding nametags, but there is no built-in middle state for this behavior:

- visible when the viewer has direct line of sight
- hidden when a block obstructs the view

This PR adds that middle state as `opaque`.

## Added Commands

### `/tab nametag opaque [player] [viewer] [-s]`

Enables opaque nametag visibility for a target player.

```mcfunction
/tab nametag opaque Steve
/tab nametag opaque Steve Alex
/tab nametag opaque Steve -s
```

### `/tab nametag opaqueview [viewer] [-s]`

Enables opaque nametag view mode for a viewer.

When enabled, the viewer sees all player nametags only when line of sight is clear. Players who join later are also handled by this viewer-level mode.

```mcfunction
/tab nametag opaqueview Alex
/tab nametag opaqueview Alex -s
```

## Behavior

### Target Mode

`/tab nametag opaque <player>` applies opaque visibility to the target player's nametag.

Other players can see that nametag only when there is no block obstruction.

### Viewer Mode

`/tab nametag opaqueview <viewer>` applies opaque visibility to everything the viewer sees.

The viewer sees all player nametags only when line of sight is clear.

## Existing Command Interaction

These commands clear opaque state where appropriate:

```text
/tab nametag show
/tab nametag hide
/tab nametag toggle
/tab nametag showview
/tab nametag hideview
/tab nametag toggleview
```

This avoids stale opaque state remaining active after switching back to normal show/hide behavior.

## Tab Completion

Tab completion was updated to include:

```text
opaque
opaqueview
```

Full command list:

```text
/tab nametag show
/tab nametag opaque
/tab nametag hide
/tab nametag toggle
/tab nametag showview
/tab nametag opaqueview
/tab nametag hideview
/tab nametag toggleview
```

## Platform Support

Line-of-sight checks were added for:

- Bukkit / Paper / Purpur
- Fabric
- Forge
- NeoForge

Proxy platforms keep the default behavior because block line-of-sight cannot be calculated there.

Folia keeps a safe fallback behavior because cross-entity line-of-sight checks are not safe from the global scheduler.

## Implementation Notes

This PR adds a new nametag invisibility reason:

```java
OPAQUE_OCCLUSION
```

Opaque nametag state is tracked separately from existing hide/show command state.

Line-of-sight checking is split into two phases:

```text
1. TAB's nametag thread snapshots player/viewer pairs.
2. The platform thread performs line-of-sight checks.
3. Results are applied back on TAB's nametag thread.
```

This avoids mutating TAB nametag state directly from the platform/server thread.

## Performance Notes

Opaque occlusion refresh runs periodically only when opaque mode is active.

If no players/viewers are using opaque mode, the refresh exits early.

The implementation avoids changing scoreboard teams unless the visibility state actually changes.

## What This PR Does Not Do

This PR does not:

- add custom rendered nametags
- add `text_display` nametags
- add armor stand nametags
- change prefix/suffix formatting
- change tablist formatting
- change chat formatting
- add persistent config storage for the command state
- add a new public API method

It only extends the existing `/tab nametag` command behavior.

## Demo

## POV :  /tab nametag show 
https://github.com/user-attachments/assets/d74df3a1-e85d-4d3a-a436-6698fe3a9e79

## POV: If that player uses `/tab nametag opaque`, or you yourself use `/tab nametag opaqueview`
https://github.com/user-attachments/assets/849eb7eb-b97a-4697-8fd6-27179177373f
### `/tab nametag opaque`

Suggested demo:

```text
1. Run /tab nametag opaque <player>.
2. Look at the player's nametag with clear line of sight.
3. Move behind a block.
4. Show that the nametag is no longer visible through the block.
```

### `/tab nametag opaqueview`

Suggested demo:

```text
1. Run /tab nametag opaqueview <viewer>.
2. Show the viewer seeing nametags normally with clear line of sight.
3. Move behind a block.
4. Show that the viewer cannot see nametags through the block.
5. Let another player join after the command.
6. Show that the newly joined player's nametag also follows opaque view behavior.
```

## Verification

Tested successfully with:

```bash
./gradlew :shared:compileJava :bukkit:compileJava :velocity:compileJava :fabric:compileJava :forge:compileJava :neoforge:compileJava --stacktrace
./gradlew :shared:test --stacktrace
./gradlew :bukkit:shadowJar :bungeecord:shadowJar :velocity:shadowJar :fabric:jar :forge:jar :neoforge:jar --stacktrace
```

Also checked:

```bash
git diff --check
```

## Build Note

The aggregate build command:

```bash
./gradlew --no-configure-on-demand :jar:build --stacktrace
```

currently fails in the existing Paperweight setup for:

```text
:bukkit:paper_1_21_4:paperweightUserdevSetup
:bukkit:paper_1_21_9:paperweightUserdevSetup
```

The failure is caused by Paperweight/Codebook being executed with the repository's Java 25 toolchain and failing with:

```text
Unsupported class file major version 69
```

The repository already sets Java toolchain 25 in:

```text
build-logic/src/main/kotlin/tab.base-conventions.gradle.kts
```

This appears to be a build tooling / Paperweight compatibility issue and is not caused by the opaque nametag source changes in this pull request.

The source modules and primary platform artifacts listed above build successfully.

## Pull Request

```text
https://github.com/Nattapat2871/TAB/pull/new/feature/nametag-opaque-view
```