### PR TITLE
[Fand] Update API dependency to 0.8.3

### DIFF
--- a/fand/build.gradle.kts
+++ b/fand/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     implementation(projects.shared)
-    compileOnly("io.fand:fand-api:0.7.8+build.1")
+    compileOnly("io.fand:fand-api:0.8.3+build.1")
 }
 
 tasks.compileJava {


### PR DESCRIPTION
## What changed
- Update the Fand compile-only API dependency from `0.7.8+build.1` to `0.8.3+build.1`.
- Keep the platform implementation and packaged runtime behavior unchanged.

## Verification
- Confirmed the `0.8.3+build.1` Maven metadata, POM, and JAR are publicly available.
- Ran `./gradlew :fand:compileJava` successfully with Java 25.