### PR TITLE
[Scoreboard] Fix line hiding with number format

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreRefresher.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreRefresher.java
@@ -44,6 +44,10 @@ public class ScoreRefresher extends RefreshableFeature implements CustomThreaded
     public void refresh(@NotNull TabPlayer refreshed, boolean force) {
         if (refreshed.scoreboardData.activeScoreboard != line.getParent()) return; //player has different scoreboard displayed
         if (refreshed.scoreboardData.numberFormatProperties.get(line) == null) return; // Shrug
+        if (line.getText().isEmpty() && numberFormat != null) {
+            line.getParent().recalculateScores(refreshed);
+            return;
+        }
         refreshed.getScoreboard().setScore(
                 ScoreboardManagerImpl.OBJECTIVE_NAME,
                 line.getPlayerName(refreshed),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardImpl.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import me.neznamy.tab.api.scoreboard.Line;
 import me.neznamy.tab.shared.Property;
+import me.neznamy.tab.shared.ProtocolVersion;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
 import me.neznamy.tab.shared.chat.component.TabComponent;
@@ -207,15 +208,23 @@ public class ScoreboardImpl extends RefreshableFeature implements me.neznamy.tab
         int score = 1;
         for (Line line : lines) {
             Property pr = p.scoreboardData.lineProperties.get((ScoreboardLine) line);
-            if (pr.getCurrentRawValue().isEmpty() || (!pr.getCurrentRawValue().isEmpty() && !pr.get().isEmpty())) {
-                ((ScoreboardLine)line).getScoreRefresher().setLineNumber(score++);
+            ScoreboardLine scoreboardLine = (ScoreboardLine) line;
+            boolean visible = pr.getCurrentRawValue().isEmpty() ?
+                    scoreboardLine.getNumberFormat() == null ||
+                            !p.scoreboardData.numberFormatProperties.get(scoreboardLine).get().isEmpty() ||
+                            (p.getVersion().getNetworkId() < ProtocolVersion.V1_20_3.getNetworkId() && scoreboardLine.getScore() != null) :
+                    !pr.get().isEmpty();
+            if (visible) {
+                scoreboardLine.getScoreRefresher().setLineNumber(score++);
                 p.getScoreboard().setScore(
                         ScoreboardManagerImpl.OBJECTIVE_NAME,
-                        ((ScoreboardLine)line).getPlayerName(p),
-                        ((ScoreboardLine)line).getScoreRefresher().getScore(p),
+                        scoreboardLine.getPlayerName(p),
+                        scoreboardLine.getScoreRefresher().getScore(p),
                         null, // Makes no sense for TAB
-                        ((ScoreboardLine) line).getScoreRefresher().getNumberFormat(p)
+                        scoreboardLine.getScoreRefresher().getNumberFormat(p)
                 );
+            } else {
+                p.getScoreboard().removeScore(ScoreboardManagerImpl.OBJECTIVE_NAME, scoreboardLine.getPlayerName(p));
             }
         }
     }


### PR DESCRIPTION
Fixes #1685

## Problem

Scoreboard lines configured with an empty left side and a conditional number format were not hidden when the number format resolved to an empty string.

## Fix

Recalculate number-format-only lines using their resolved number-format output. Remove stale score entries when the complete line becomes empty, while preserving literal spacer lines, legacy explicit scores, and existing visible number-format behavior.

## Verification

- `:shared:compileJava` with JDK 25.0.3
- `:bukkit:compileJava` with JDK 25.0.3
- `:shared:check :bukkit:check` with JDK 25.0.3; available test source sets report `NO-SOURCE`
- `git diff --check`
- Live Paper 26.1.2 before/after screenshots confirm the blank row is removed and right-side number-format text remains visible.
- Live Paper 26.1.2 rendering was tested locally; Velocity was not tested.
- [Issue evidence comment](https://github.com/NEZNAMY/TAB/issues/1685#issuecomment-5228153086) links the before/after renders and exact `config.yml` used.

## CI note

The repository Build workflow currently triggers only on pushes to `master`, so no GitHub Actions experimental artifact is generated for this pull-request branch.