### PR TITLE
[Conditions] Fix nested conditional placeholder refresh propagation

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/placeholders/conditions/Condition.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/placeholders/conditions/Condition.java
@@ -49,13 +49,17 @@ public class Condition {
 
     /**
      * Refresh interval of placeholder created from this condition.
-     * It is calculated based on nested placeholders used in sub-conditions.
+     * It is calculated based on placeholders used in condition expressions.
      */
     private int refresh = -1;
 
-    /** List of all placeholders used inside this condition */
+    /** List of placeholders used inside this condition's expressions */
     @NotNull
     private final List<PlaceholderReference> placeholdersInConditions = new ArrayList<>();
+
+    /** List of placeholders used in this condition's output */
+    @NotNull
+    private final List<PlaceholderReference> placeholdersInOutput = new ArrayList<>();
 
     @Nullable
     private TabPlaceholder placeholder;
@@ -125,6 +129,13 @@ public class Condition {
                 placeholdersInConditions.addAll(Arrays.stream(comparator.getRightSide().getPlaceholders()).map(ConditionPlaceholder::getRealPlaceholder).collect(Collectors.toList()));
             }
         }
+        for (String output : Arrays.asList(yes, no)) {
+            for (String identifier : PlaceholderManagerImpl.detectPlaceholders(output)) {
+                if (!identifier.equals(getPlaceholderIdentifier())) {
+                    placeholdersInOutput.add(TAB.getInstance().getPlaceholderManager().getPlaceholderReference(identifier));
+                }
+            }
+        }
     }
 
     /**
@@ -161,11 +172,28 @@ public class Condition {
      * Configures refresh interval and registers nested placeholders
      */
     public void finishSetup() {
-        for (PlaceholderReference placeholder : placeholdersInConditions) {
-            if (placeholder.getRefresh() != -1 && (placeholder.getRefresh() < refresh || refresh == -1)) {
-                refresh = placeholder.getRefresh();
+        updateRefresh();
+        registerPlaceholder();
+        for (PlaceholderReference reference : getAllPlaceholders()) {
+            TabPlaceholder placeholder = reference.getHandle();
+            placeholder.addParent(this.placeholder);
+            if (hasRelationalContent()) {
+                placeholder.addParent(relationalPlaceholder);
             }
+            this.placeholder.addChild(placeholder);
+            relationalPlaceholder.addChild(placeholder);
         }
+        TAB.getInstance().getPlaceholderManager().addUsedPlaceholderReferences(getAllPlaceholders());
+    }
+
+    /**
+     * Registers this condition's own placeholders before dependencies are wired.
+     * This is required for nested conditions, whose references may be created
+     * before the referenced condition itself is registered.
+     */
+    public void registerPlaceholder() {
+        if (placeholder != null) return;
+        updateRefresh();
         PlaceholderManagerImpl manager = TAB.getInstance().getPlaceholderManager();
         String identifier = getPlaceholderIdentifier();
         String relIdentifier = getRelationalPlaceholderIdentifier();
@@ -192,16 +220,21 @@ public class Condition {
                     p -> getText((TabPlayer) p, (TabPlayer) p)
             );
         }
+    }
+
+    private void updateRefresh() {
         for (PlaceholderReference reference : placeholdersInConditions) {
-            TabPlaceholder placeholder = reference.getHandle();
-            placeholder.addParent(this.placeholder);
-            if (hasRelationalContent()) {
-                placeholder.addParent(relationalPlaceholder);
+            if (reference.getRefresh() != -1 && (reference.getRefresh() < refresh || refresh == -1)) {
+                refresh = reference.getRefresh();
             }
-            this.placeholder.addChild(placeholder);
-            relationalPlaceholder.addChild(placeholder);
         }
-        TAB.getInstance().getPlaceholderManager().addUsedPlaceholderReferences(placeholdersInConditions);
+    }
+
+    @NotNull
+    private List<PlaceholderReference> getAllPlaceholders() {
+        List<PlaceholderReference> result = new ArrayList<>(placeholdersInConditions);
+        result.addAll(placeholdersInOutput);
+        return result;
     }
 
     /**

--- a/shared/src/main/java/me/neznamy/tab/shared/placeholders/conditions/ConditionManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/placeholders/conditions/ConditionManager.java
@@ -67,6 +67,9 @@ public class ConditionManager {
      */
     public void finishSetups() {
         for (Condition c : registeredConditions.values()) {
+            c.registerPlaceholder();
+        }
+        for (Condition c : registeredConditions.values()) {
             c.finishSetup();
         }
     }


### PR DESCRIPTION
## Summary

Fixes stale or incorrect output in nested conditional placeholder chains.

## Changes

- Detect placeholders used in both condition outputs during setup.
- Register all named conditions before linking placeholder dependencies.
- Link expression and output placeholders after all condition handles exist.
- Preserve refresh propagation through nested condition chains.

## Verification

- `:shared:check :bukkit:check :velocity:check` passed.
- Paper 26.2 and Velocity artifacts built successfully.
- Verified with a nested-condition regression harness.
- Verified in-game with a controlled 1–1000 ms test value.

### Evidence


https://github.com/user-attachments/assets/4990975c-73d2-4aaf-93d1-6cc7b74d4e84



the recording uses a test-only numeric placeholder to exercise the same nested condition refresh behavior across the ping ranges.

The repository-wide build currently encounters unrelated Paperweight remapping failures in the `paper_1_21_4` and `paper_1_21_9` modules; the affected shared, Bukkit, Velocity, and Paper 26.2 targets pass.
