### PR TITLE
Fix VSA downstream sidebar yielding race

### DIFF
--- a/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardManagerImpl.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/scoreboard/ScoreboardManagerImpl.java
@@ -189,6 +189,34 @@ public class ScoreboardManagerImpl extends RefreshableFeature implements Scorebo
         }
     }
 
+    /**
+     * Handles a sidebar display sent through VelocityScoreboardAPI.
+     *
+     * <p>VelocityScoreboardAPI gives proxy objectives priority over downstream
+     * objectives. Its display event is therefore the last opportunity to remove
+     * TAB's proxy objective before the downstream display packet is cancelled.
+     * This method is intentionally called synchronously by the Velocity hook.</p>
+     *
+     * @param receiver
+     *          player receiving the packet
+     * @param slot
+     *          display slot
+     * @param objective
+     *          objective assigned to the slot, or {@code null}
+     */
+    public void onVelocityScoreboardDisplay(@NotNull TabPlayer receiver, int slot, @Nullable String objective) {
+        if (slot != Scoreboard.DisplaySlot.SIDEBAR.ordinal()) {
+            return;
+        }
+        if (objective == null) {
+            restoreAfterVelocityScoreboard(receiver);
+        } else if (!objective.equals(OBJECTIVE_NAME)) {
+            TAB.getInstance().debug("Player " + receiver.getName() + " received scoreboard called " + objective + ", releasing TAB's proxy scoreboard.");
+            receiver.scoreboardData.otherPluginScoreboard = objective;
+            unregisterScoreboard(receiver);
+        }
+    }
+
     @Override
     public void onObjective(@NotNull TabPlayer receiver, int action, @NotNull String objective) {
         if (action == Scoreboard.ObjectiveAction.UNREGISTER && objective.equals(receiver.scoreboardData.otherPluginScoreboard)) {
@@ -198,6 +226,30 @@ public class ScoreboardManagerImpl extends RefreshableFeature implements Scorebo
                 receiver.getScoreboard().setDisplaySlot(OBJECTIVE_NAME, Scoreboard.DisplaySlot.SIDEBAR);
             }
         }
+    }
+
+    /**
+     * Handles removal of a downstream objective reported by VelocityScoreboardAPI.
+     * This is synchronous for the same reason as {@link #onVelocityScoreboardDisplay(TabPlayer, int, String)}.
+     *
+     * @param receiver
+     *          player receiving the packet
+     * @param objective
+     *          removed objective
+     */
+    public void onVelocityScoreboardUnregister(@NotNull TabPlayer receiver, @NotNull String objective) {
+        if (objective.equals(receiver.scoreboardData.otherPluginScoreboard)) {
+            restoreAfterVelocityScoreboard(receiver);
+        }
+    }
+
+    private void restoreAfterVelocityScoreboard(@NotNull TabPlayer receiver) {
+        if (receiver.scoreboardData.otherPluginScoreboard == null) {
+            return;
+        }
+        TAB.getInstance().debug("Player " + receiver.getName() + " no longer has another scoreboard, restoring TAB's proxy scoreboard.");
+        receiver.scoreboardData.otherPluginScoreboard = null;
+        sendHighestScoreboard(receiver);
     }
 
     @Override

--- a/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
+++ b/velocity/src/main/java/me/neznamy/tab/platforms/velocity/VelocityPlatform.java
@@ -22,6 +22,7 @@ import me.neznamy.tab.shared.chat.component.TabComponent;
 import me.neznamy.tab.shared.chat.component.TabTextComponent;
 import me.neznamy.tab.shared.features.injection.PipelineInjector;
 import me.neznamy.tab.shared.features.proxy.ProxySupport;
+import me.neznamy.tab.shared.features.scoreboard.ScoreboardManagerImpl;
 import me.neznamy.tab.shared.placeholders.expansion.EmptyTabExpansion;
 import me.neznamy.tab.shared.placeholders.expansion.TabExpansion;
 import me.neznamy.tab.shared.platform.BossBar;
@@ -147,18 +148,22 @@ public class VelocityPlatform extends ProxyPlatform {
         plugin.getServer().getEventManager().register(plugin, ObjectiveEvent.Display.class, e -> {
             TAB tab = TAB.getInstance();
             if (tab.isPluginDisabled()) return;
-            tab.getCPUManager().runTask(() -> {
-                TabPlayer player = tab.getPlayer(e.getPlayer().getUniqueId());
-                if (player != null) tab.getFeatureManager().onDisplayObjective(player, e.getNewSlot().ordinal(), e.getObjectiveName());
-            });
+            TabPlayer player = tab.getPlayer(e.getPlayer().getUniqueId());
+            if (player == null) return;
+            ScoreboardManagerImpl scoreboard = tab.getFeatureManager().getFeature(TabConstants.Feature.SCOREBOARD);
+            if (scoreboard != null) {
+                scoreboard.onVelocityScoreboardDisplay(player, e.getNewSlot().ordinal(), e.getObjectiveName());
+            }
         });
         plugin.getServer().getEventManager().register(plugin, ObjectiveEvent.Unregister.class, e -> {
             TAB tab = TAB.getInstance();
             if (tab.isPluginDisabled()) return;
-            tab.getCPUManager().runTask(() -> {
-                TabPlayer player = tab.getPlayer(e.getPlayer().getUniqueId());
-                if (player != null) tab.getFeatureManager().onObjective(player, Scoreboard.ObjectiveAction.UNREGISTER, e.getObjectiveName());
-            });
+            TabPlayer player = tab.getPlayer(e.getPlayer().getUniqueId());
+            if (player == null) return;
+            ScoreboardManagerImpl scoreboard = tab.getFeatureManager().getFeature(TabConstants.Feature.SCOREBOARD);
+            if (scoreboard != null) {
+                scoreboard.onVelocityScoreboardUnregister(player, e.getObjectiveName());
+            }
         });
     }
 


### PR DESCRIPTION
Fixes #1711

## Cause

VelocityScoreboardAPI gives proxy objectives priority over downstream objectives. TAB queued VSA `ObjectiveEvent.Display` handling through `CPUManager`, so the VSA packet handler checked the proxy sidebar slot before TAB had yielded it and cancelled the downstream display packet.

## Changes

- Handle VSA display/unregister events synchronously in the Velocity hook.
- When a downstream sidebar is displayed, unregister TAB's proxy objective before VSA performs its proxy-slot priority check.
- When that downstream objective is removed, rebuild the highest applicable TAB scoreboard.
- Preserve the existing generic asynchronous packet path for all non-VSA platforms.

## Verification

- `JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-22.jdk/Contents/Home ./gradlew :velocity:shadowJar --offline --no-daemon`
- Build successful; the Velocity implementation is compiled for Java 21 (classfile major version 65).

The live server trace that motivated this change is included in #1711. Runtime validation on the affected proxy network is pending deployment of this build.
