### PR TITLE
[API] Add BelowName and PlayerListObjective managers

### DIFF
--- a/api/src/main/java/me/neznamy/tab/api/TabAPI.java
+++ b/api/src/main/java/me/neznamy/tab/api/TabAPI.java
@@ -4,9 +4,11 @@ import java.util.UUID;
 
 import lombok.NonNull;
 import lombok.Setter;
+import me.neznamy.tab.api.belowname.BelowNameManager;
 import me.neznamy.tab.api.bossbar.BossBarManager;
 import me.neznamy.tab.api.event.EventBus;
 import me.neznamy.tab.api.placeholder.PlaceholderManager;
+import me.neznamy.tab.api.playerlistobjective.PlayerListObjectiveManager;
 import me.neznamy.tab.api.scoreboard.ScoreboardManager;
 import me.neznamy.tab.api.tablist.SortingManager;
 import me.neznamy.tab.api.tablist.HeaderFooterManager;
@@ -82,6 +84,22 @@ public abstract class TabAPI {
      * @return  scoreboard manager
      */
     public abstract @Nullable ScoreboardManager getScoreboardManager();
+
+    /**
+     * Returns belowname manager instance. Unlike other features, this one is returned even if
+     * it is disabled in config, which allows enabling it for specific players using the API.
+     *
+     * @return  belowname manager
+     */
+    public abstract @Nullable BelowNameManager getBelowNameManager();
+
+    /**
+     * Returns playerlist objective manager instance. Unlike other features, this one is returned
+     * even if it is disabled in config, which allows enabling it for specific players using the API.
+     *
+     * @return  playerlist objective manager
+     */
+    public abstract @Nullable PlayerListObjectiveManager getPlayerListObjectiveManager();
 
     /**
      * Returns team manager instance if the feature is enabled. If not, returns {@code null}.

--- a/api/src/main/java/me/neznamy/tab/api/belowname/BelowNameManager.java
+++ b/api/src/main/java/me/neznamy/tab/api/belowname/BelowNameManager.java
@@ -1,0 +1,75 @@
+package me.neznamy.tab.api.belowname;
+
+import lombok.NonNull;
+import me.neznamy.tab.api.TabAPI;
+import me.neznamy.tab.api.TabPlayer;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Interface for manipulating the belowname objective of individual players.
+ * <p>
+ * Instance can be obtained using {@link TabAPI#getBelowNameManager()}.
+ * Unlike other features, this one is available even if it is disabled in config,
+ * which allows enabling it for specific players using {@link #setEnabled(TabPlayer, Boolean)}.
+ */
+@SuppressWarnings("unused") // API class
+public interface BelowNameManager {
+
+    /**
+     * Forces the objective to be visible or hidden for specified player, overriding
+     * both the config option and the disable condition. Hiding the objective also
+     * removes the player's score from everyone else's view. Use {@code null} to
+     * give the control back to configuration.
+     *
+     * @param   player
+     *          Player to set visibility for
+     * @param   enabled
+     *          Forced visibility or {@code null} to reset back to configuration
+     * @see     #getCustomEnabled(TabPlayer)
+     */
+    void setEnabled(@NonNull TabPlayer player, @Nullable Boolean enabled);
+
+    /**
+     * Returns forced visibility assigned using {@link #setEnabled(TabPlayer, Boolean)}.
+     * If no value is forced, returns {@code null}.
+     *
+     * @param   player
+     *          Player to get forced visibility of
+     * @return  Forced visibility or {@code null} if not forced
+     * @see     #setEnabled(TabPlayer, Boolean)
+     */
+    @Nullable Boolean getCustomEnabled(@NonNull TabPlayer player);
+
+    /**
+     * Changes score of specified player to provided value for everyone who can see it.
+     * This also replaces the number format with the same value. Use {@code null} to reset
+     * value back to the configured one.
+     *
+     * @param   player
+     *          Player to change score of
+     * @param   value
+     *          New score value or {@code null} to reset back to configuration
+     */
+    void setValue(@NonNull TabPlayer player, @Nullable Integer value);
+
+    /**
+     * Changes objective title of specified player to provided value. Supports placeholders,
+     * as well as any supported RGB formats. Use {@code null} to reset value back to the
+     * configured one.
+     *
+     * @param   player
+     *          Player to change objective title of
+     * @param   title
+     *          New objective title or {@code null} to reset back to configuration
+     */
+    void setTitle(@NonNull TabPlayer player, @Nullable String title);
+
+    /**
+     * Removes all values forced using this API for specified player and gives the control
+     * back to configuration.
+     *
+     * @param   player
+     *          Player to remove forced values of
+     */
+    void reset(@NonNull TabPlayer player);
+}

--- a/api/src/main/java/me/neznamy/tab/api/belowname/BelowNameManager.java
+++ b/api/src/main/java/me/neznamy/tab/api/belowname/BelowNameManager.java
@@ -17,8 +17,8 @@ public interface BelowNameManager {
 
     /**
      * Forces the objective to be visible or hidden for specified player, overriding
-     * both the config option and the disable condition. Hiding the objective also
-     * removes the player's score from everyone else's view. Use {@code null} to
+     * both the config option and the disable condition. This only affects what the
+     * player sees, not how the player is displayed to others. Use {@code null} to
      * give the control back to configuration.
      *
      * @param   player
@@ -31,7 +31,7 @@ public interface BelowNameManager {
 
     /**
      * Returns forced visibility assigned using {@link #setEnabled(TabPlayer, Boolean)}.
-     * If no value is forced, returns {@code null}.
+     * If no visibility is forced, returns {@code null}.
      *
      * @param   player
      *          Player to get forced visibility of
@@ -41,16 +41,56 @@ public interface BelowNameManager {
     @Nullable Boolean getCustomEnabled(@NonNull TabPlayer player);
 
     /**
-     * Changes score of specified player to provided value for everyone who can see it.
-     * This also replaces the number format with the same value. Use {@code null} to reset
-     * value back to the configured one.
+     * Changes score value of specified player to provided value. Supports placeholders,
+     * however, the value must evaluate to a number. Only 1.20.2 and lower clients display
+     * this value, newer clients display the number format instead. Use {@code null} to
+     * reset value back to the configured one.
      *
      * @param   player
-     *          Player to change score of
+     *          Player to change score value of
      * @param   value
      *          New score value or {@code null} to reset back to configuration
+     * @see     #getCustomValue(TabPlayer)
+     * @see     #setFancyValue(TabPlayer, String)
      */
-    void setValue(@NonNull TabPlayer player, @Nullable Integer value);
+    void setValue(@NonNull TabPlayer player, @Nullable String value);
+
+    /**
+     * Returns score value assigned using {@link #setValue(TabPlayer, String)}.
+     * If no value is assigned, returns {@code null}.
+     *
+     * @param   player
+     *          Player to get custom score value of
+     * @return  Custom score value assigned using the API
+     * @see     #setValue(TabPlayer, String)
+     */
+    @Nullable String getCustomValue(@NonNull TabPlayer player);
+
+    /**
+     * Changes number format of specified player to provided value. Supports placeholders,
+     * as well as any supported RGB formats. Only 1.20.3+ clients display the number format,
+     * older clients display the score value instead. If it evaluates to an empty string, the
+     * score is not displayed at all. Use {@code null} to reset value back to the configured one.
+     *
+     * @param   player
+     *          Player to change number format of
+     * @param   fancyValue
+     *          New number format or {@code null} to reset back to configuration
+     * @see     #getCustomFancyValue(TabPlayer)
+     * @see     #setValue(TabPlayer, String)
+     */
+    void setFancyValue(@NonNull TabPlayer player, @Nullable String fancyValue);
+
+    /**
+     * Returns number format assigned using {@link #setFancyValue(TabPlayer, String)}.
+     * If no number format is assigned, returns {@code null}.
+     *
+     * @param   player
+     *          Player to get custom number format of
+     * @return  Custom number format assigned using the API
+     * @see     #setFancyValue(TabPlayer, String)
+     */
+    @Nullable String getCustomFancyValue(@NonNull TabPlayer player);
 
     /**
      * Changes objective title of specified player to provided value. Supports placeholders,
@@ -61,15 +101,18 @@ public interface BelowNameManager {
      *          Player to change objective title of
      * @param   title
      *          New objective title or {@code null} to reset back to configuration
+     * @see     #getCustomTitle(TabPlayer)
      */
     void setTitle(@NonNull TabPlayer player, @Nullable String title);
 
     /**
-     * Removes all values forced using this API for specified player and gives the control
-     * back to configuration.
+     * Returns objective title assigned using {@link #setTitle(TabPlayer, String)}.
+     * If no title is assigned, returns {@code null}.
      *
      * @param   player
-     *          Player to remove forced values of
+     *          Player to get custom objective title of
+     * @return  Custom objective title assigned using the API
+     * @see     #setTitle(TabPlayer, String)
      */
-    void reset(@NonNull TabPlayer player);
+    @Nullable String getCustomTitle(@NonNull TabPlayer player);
 }

--- a/api/src/main/java/me/neznamy/tab/api/playerlistobjective/PlayerListObjectiveManager.java
+++ b/api/src/main/java/me/neznamy/tab/api/playerlistobjective/PlayerListObjectiveManager.java
@@ -17,8 +17,9 @@ public interface PlayerListObjectiveManager {
 
     /**
      * Forces the objective to be visible or hidden for specified player, overriding
-     * both the config option and the disable condition. Use {@code null} to give the
-     * control back to configuration.
+     * both the config option and the disable condition. This only affects what the
+     * player sees, not how the player is displayed to others. Use {@code null} to
+     * give the control back to configuration.
      *
      * @param   player
      *          Player to set visibility for
@@ -30,7 +31,7 @@ public interface PlayerListObjectiveManager {
 
     /**
      * Returns forced visibility assigned using {@link #setEnabled(TabPlayer, Boolean)}.
-     * If no value is forced, returns {@code null}.
+     * If no visibility is forced, returns {@code null}.
      *
      * @param   player
      *          Player to get forced visibility of
@@ -40,28 +41,80 @@ public interface PlayerListObjectiveManager {
     @Nullable Boolean getCustomEnabled(@NonNull TabPlayer player);
 
     /**
-     * Changes score of specified player to provided value for everyone who can see it.
-     * This also replaces the number format with the same value. Use {@code null} to reset
-     * value back to the configured one.
+     * Changes score value of specified player to provided value. Supports placeholders,
+     * however, the value must evaluate to a number. Only 1.20.2 and lower clients display
+     * this value, newer clients display the number format instead. Use {@code null} to
+     * reset value back to the configured one.
      *
      * @param   player
-     *          Player to change score of
+     *          Player to change score value of
      * @param   value
      *          New score value or {@code null} to reset back to configuration
+     * @see     #getCustomValue(TabPlayer)
+     * @see     #setFancyValue(TabPlayer, String)
      */
-    void setValue(@NonNull TabPlayer player, @Nullable Integer value);
+    void setValue(@NonNull TabPlayer player, @Nullable String value);
+
+    /**
+     * Returns score value assigned using {@link #setValue(TabPlayer, String)}.
+     * If no value is assigned, returns {@code null}.
+     *
+     * @param   player
+     *          Player to get custom score value of
+     * @return  Custom score value assigned using the API
+     * @see     #setValue(TabPlayer, String)
+     */
+    @Nullable String getCustomValue(@NonNull TabPlayer player);
+
+    /**
+     * Changes number format of specified player to provided value. Supports placeholders,
+     * as well as any supported RGB formats. Only 1.20.3+ clients display the number format,
+     * older clients display the score value instead. Use {@code null} to reset value back
+     * to the configured one.
+     *
+     * @param   player
+     *          Player to change number format of
+     * @param   fancyValue
+     *          New number format or {@code null} to reset back to configuration
+     * @see     #getCustomFancyValue(TabPlayer)
+     * @see     #setValue(TabPlayer, String)
+     */
+    void setFancyValue(@NonNull TabPlayer player, @Nullable String fancyValue);
+
+    /**
+     * Returns number format assigned using {@link #setFancyValue(TabPlayer, String)}.
+     * If no number format is assigned, returns {@code null}.
+     *
+     * @param   player
+     *          Player to get custom number format of
+     * @return  Custom number format assigned using the API
+     * @see     #setFancyValue(TabPlayer, String)
+     */
+    @Nullable String getCustomFancyValue(@NonNull TabPlayer player);
 
     /**
      * Changes objective title of specified player to provided value. Supports placeholders,
-     * as well as any supported RGB formats. Use {@code null} to reset value back to the
-     * configured one.
+     * as well as any supported RGB formats. The title is only visible on Bedrock Edition.
+     * Use {@code null} to reset value back to the configured one.
      *
      * @param   player
      *          Player to change objective title of
      * @param   title
      *          New objective title or {@code null} to reset back to configuration
+     * @see     #getCustomTitle(TabPlayer)
      */
     void setTitle(@NonNull TabPlayer player, @Nullable String title);
+
+    /**
+     * Returns objective title assigned using {@link #setTitle(TabPlayer, String)}.
+     * If no title is assigned, returns {@code null}.
+     *
+     * @param   player
+     *          Player to get custom objective title of
+     * @return  Custom objective title assigned using the API
+     * @see     #setTitle(TabPlayer, String)
+     */
+    @Nullable String getCustomTitle(@NonNull TabPlayer player);
 
     /**
      * Changes render type of the objective for specified player. Use {@code null} to reset
@@ -71,17 +124,20 @@ public interface PlayerListObjectiveManager {
      *          Player to change render type of
      * @param   renderType
      *          New render type or {@code null} to reset back to configuration
+     * @see     #getCustomRenderType(TabPlayer)
      */
     void setRenderType(@NonNull TabPlayer player, @Nullable RenderType renderType);
 
     /**
-     * Removes all values forced using this API for specified player and gives the control
-     * back to configuration.
+     * Returns render type assigned using {@link #setRenderType(TabPlayer, RenderType)}.
+     * If no render type is assigned, returns {@code null}.
      *
      * @param   player
-     *          Player to remove forced values of
+     *          Player to get custom render type of
+     * @return  Custom render type assigned using the API
+     * @see     #setRenderType(TabPlayer, RenderType)
      */
-    void reset(@NonNull TabPlayer player);
+    @Nullable RenderType getCustomRenderType(@NonNull TabPlayer player);
 
     /**
      * Render type of the objective, defining how the score is displayed.

--- a/api/src/main/java/me/neznamy/tab/api/playerlistobjective/PlayerListObjectiveManager.java
+++ b/api/src/main/java/me/neznamy/tab/api/playerlistobjective/PlayerListObjectiveManager.java
@@ -1,0 +1,97 @@
+package me.neznamy.tab.api.playerlistobjective;
+
+import lombok.NonNull;
+import me.neznamy.tab.api.TabAPI;
+import me.neznamy.tab.api.TabPlayer;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Interface for manipulating the playerlist objective of individual players.
+ * <p>
+ * Instance can be obtained using {@link TabAPI#getPlayerListObjectiveManager()}.
+ * Unlike other features, this one is available even if it is disabled in config,
+ * which allows enabling it for specific players using {@link #setEnabled(TabPlayer, Boolean)}.
+ */
+@SuppressWarnings("unused") // API class
+public interface PlayerListObjectiveManager {
+
+    /**
+     * Forces the objective to be visible or hidden for specified player, overriding
+     * both the config option and the disable condition. Use {@code null} to give the
+     * control back to configuration.
+     *
+     * @param   player
+     *          Player to set visibility for
+     * @param   enabled
+     *          Forced visibility or {@code null} to reset back to configuration
+     * @see     #getCustomEnabled(TabPlayer)
+     */
+    void setEnabled(@NonNull TabPlayer player, @Nullable Boolean enabled);
+
+    /**
+     * Returns forced visibility assigned using {@link #setEnabled(TabPlayer, Boolean)}.
+     * If no value is forced, returns {@code null}.
+     *
+     * @param   player
+     *          Player to get forced visibility of
+     * @return  Forced visibility or {@code null} if not forced
+     * @see     #setEnabled(TabPlayer, Boolean)
+     */
+    @Nullable Boolean getCustomEnabled(@NonNull TabPlayer player);
+
+    /**
+     * Changes score of specified player to provided value for everyone who can see it.
+     * This also replaces the number format with the same value. Use {@code null} to reset
+     * value back to the configured one.
+     *
+     * @param   player
+     *          Player to change score of
+     * @param   value
+     *          New score value or {@code null} to reset back to configuration
+     */
+    void setValue(@NonNull TabPlayer player, @Nullable Integer value);
+
+    /**
+     * Changes objective title of specified player to provided value. Supports placeholders,
+     * as well as any supported RGB formats. Use {@code null} to reset value back to the
+     * configured one.
+     *
+     * @param   player
+     *          Player to change objective title of
+     * @param   title
+     *          New objective title or {@code null} to reset back to configuration
+     */
+    void setTitle(@NonNull TabPlayer player, @Nullable String title);
+
+    /**
+     * Changes render type of the objective for specified player. Use {@code null} to reset
+     * value back to the configured one.
+     *
+     * @param   player
+     *          Player to change render type of
+     * @param   renderType
+     *          New render type or {@code null} to reset back to configuration
+     */
+    void setRenderType(@NonNull TabPlayer player, @Nullable RenderType renderType);
+
+    /**
+     * Removes all values forced using this API for specified player and gives the control
+     * back to configuration.
+     *
+     * @param   player
+     *          Player to remove forced values of
+     */
+    void reset(@NonNull TabPlayer player);
+
+    /**
+     * Render type of the objective, defining how the score is displayed.
+     */
+    enum RenderType {
+
+        /** Score is displayed as a number */
+        INTEGER,
+
+        /** Score is displayed as hearts */
+        HEARTS
+    }
+}

--- a/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/FeatureManager.java
@@ -596,12 +596,8 @@ public class FeatureManager {
         if (config.getScoreboard() != null) {
             registerFeature(TabConstants.Feature.SCOREBOARD, new ScoreboardManagerImpl(config.getScoreboard()));
         }
-        if (config.getPlayerlistObjective() != null) {
-            registerFeature(TabConstants.Feature.YELLOW_NUMBER, new YellowNumber(config.getPlayerlistObjective()));
-        }
-        if (config.getBelowname() != null) {
-            registerFeature(TabConstants.Feature.BELOW_NAME, new BelowName(config.getBelowname()));
-        }
+        registerFeature(TabConstants.Feature.YELLOW_NUMBER, new YellowNumber(config.getPlayerlistObjective()));
+        registerFeature(TabConstants.Feature.BELOW_NAME, new BelowName(config.getBelowname()));
         if (config.getSorting() != null) {
             registerFeature(TabConstants.Feature.SORTING, new Sorting(config.getSorting()));
         }

--- a/shared/src/main/java/me/neznamy/tab/shared/TAB.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/TAB.java
@@ -3,7 +3,9 @@ package me.neznamy.tab.shared;
 import lombok.Getter;
 import lombok.Setter;
 import me.neznamy.tab.api.TabAPI;
+import me.neznamy.tab.api.belowname.BelowNameManager;
 import me.neznamy.tab.api.bossbar.BossBarManager;
+import me.neznamy.tab.api.playerlistobjective.PlayerListObjectiveManager;
 import me.neznamy.tab.api.scoreboard.ScoreboardManager;
 import me.neznamy.tab.api.tablist.HeaderFooterManager;
 import me.neznamy.tab.api.tablist.SortingManager;
@@ -313,6 +315,16 @@ public class TAB extends TabAPI {
     @Override
     public @Nullable ScoreboardManager getScoreboardManager() {
         return featureManager.getFeature(TabConstants.Feature.SCOREBOARD);
+    }
+
+    @Override
+    public @Nullable BelowNameManager getBelowNameManager() {
+        return featureManager.getFeature(TabConstants.Feature.BELOW_NAME);
+    }
+
+    @Override
+    public @Nullable PlayerListObjectiveManager getPlayerListObjectiveManager() {
+        return featureManager.getFeature(TabConstants.Feature.YELLOW_NUMBER);
     }
 
     @Override

--- a/shared/src/main/java/me/neznamy/tab/shared/config/files/Config.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/config/files/Config.java
@@ -40,7 +40,7 @@ public class Config {
     @NotNull private final ConfigurationFile config = new YamlConfigurationFile(getClass().getClassLoader().getResourceAsStream("config/config.yml"),
             new File(TAB.getInstance().getDataFolder(), "config.yml"));
 
-    @Nullable private BelowNameConfiguration belowname;
+    @NotNull private final BelowNameConfiguration belowname;
     @Nullable private BossBarConfiguration bossbar;
     @NotNull private final ConditionsSection conditions;
     @Nullable private GlobalPlayerListConfiguration globalPlayerList;
@@ -52,7 +52,7 @@ public class Config {
     @NotNull private final PlaceholderRefreshConfiguration refresh;
     @NotNull private final PlaceholderReplacementsConfiguration replacements;
     @NotNull private final PlaceholdersConfiguration placeholders;
-    @Nullable private PlayerListObjectiveConfiguration playerlistObjective;
+    @NotNull private final PlayerListObjectiveConfiguration playerlistObjective;
     @Nullable private ScoreboardConfiguration scoreboard;
     @Nullable private SortingConfiguration sorting;
     @Nullable private TablistFormattingConfiguration tablistFormatting;
@@ -95,8 +95,9 @@ public class Config {
         replacements = PlaceholderReplacementsConfiguration.fromSection(config.getConfigurationSection("placeholder-output-replacements"));
         placeholders = PlaceholdersConfiguration.fromSection(config.getConfigurationSection("placeholders"));
         components = ComponentConfiguration.fromSection(config.getConfigurationSection("components"));
+        belowname = BelowNameConfiguration.fromSection(config.getConfigurationSection("belowname-objective"));
+        playerlistObjective = PlayerListObjectiveConfiguration.fromSection(config.getConfigurationSection("playerlist-objective"));
 
-        if (config.getBoolean("belowname-objective.enabled", false)) belowname = BelowNameConfiguration.fromSection(config.getConfigurationSection("belowname-objective"));
         if (config.getBoolean("bossbar.enabled", false)) bossbar = BossBarConfiguration.fromSection(config.getConfigurationSection("bossbar"));
         if (config.getBoolean("global-playerlist.enabled", false)) globalPlayerList = GlobalPlayerListConfiguration.fromSection(config.getConfigurationSection("global-playerlist"));
         if (config.getBoolean("header-footer.enabled", true)) headerFooter = HeaderFooterConfiguration.fromSection(config.getConfigurationSection("header-footer"));
@@ -104,7 +105,6 @@ public class Config {
         if (config.getBoolean("mysql.enabled", false)) mysql = MySQLConfiguration.fromSection(config.getConfigurationSection("mysql"));
         if (config.getBoolean("per-world-playerlist.enabled", false)) perWorldPlayerList = PerWorldPlayerListConfiguration.fromSection(config.getConfigurationSection("per-world-playerlist"));
         if (config.getBoolean("ping-spoof.enabled", false)) pingSpoof = PingSpoofConfiguration.fromSection(config.getConfigurationSection("ping-spoof"));
-        if (config.getBoolean("playerlist-objective.enabled", true)) playerlistObjective = PlayerListObjectiveConfiguration.fromSection(config.getConfigurationSection("playerlist-objective"));
         if (config.getBoolean("scoreboard.enabled", false)) scoreboard = ScoreboardConfiguration.fromSection(config.getConfigurationSection("scoreboard"));
         if (config.getBoolean("scoreboard-teams.enabled", true) || config.getBoolean("layout.enabled", false)) sorting = SortingConfiguration.fromSection(config.getConfigurationSection("scoreboard-teams"));
         if (config.getBoolean("tablist-name-formatting.enabled", false)) tablistFormatting = TablistFormattingConfiguration.fromSection(config.getConfigurationSection("tablist-name-formatting"));
@@ -118,7 +118,7 @@ public class Config {
                                 " fake players, making per world playerlist completely useless as real players are pushed out of the playerlist. " +
                         "Disable per world playerlist for the same result, but with better performance.");
             }
-            if (playerlistObjective != null) {
+            if (playerlistObjective.isEnabled()) {
                 TAB.getInstance().getConfigHelper().startup().startupWarn(config.getFile(), "Layout feature breaks playerlist-objective feature, because it replaces real player with fake slots " +
                         "with different usernames for more reliable functionality. Disable playerlist-objective feature, as it will only look bad " +
                         "and consume resources.");

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
@@ -268,10 +268,6 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
     public void setScore(@NotNull TabPlayer viewer, @NotNull TabPlayer scoreHolder, int value, @NotNull String fancyValue) {
         if (viewer.belowNameData.disabled.get()) return;
         if (viewer.server != scoreHolder.server || viewer.world != scoreHolder.world) return; // Viewer definitely cannot see this player in game
-        if (Boolean.FALSE.equals(scoreHolder.belowNameData.forcedEnabled)) {
-            viewer.getScoreboard().removeScore(OBJECTIVE_NAME, scoreHolder.getNickname());
-            return;
-        }
         if (viewer.canSee(scoreHolder)) {
             if (fancyValue.isEmpty() && viewer.getVersionId() >= ProtocolVersion.V26_2.getNetworkId()) {
                 viewer.getScoreboard().removeScore(OBJECTIVE_NAME, scoreHolder.getNickname());
@@ -351,7 +347,6 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
             p.ensureLoaded();
             p.belowNameData.forcedEnabled = enabled;
             applyDisabledState(p, enabled == null ? configuredDisabled(p) : !enabled);
-            refresh(p, true);
         }, getFeatureName(), "Processing API call (setEnabled)"));
     }
 
@@ -363,17 +358,41 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
     }
 
     @Override
-    public void setValue(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable Integer value) {
+    public void setValue(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable String value) {
         ensureActive();
         customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
             TabPlayer p = (TabPlayer) player;
             p.ensureLoaded();
-            String newValue = value == null ? null : String.valueOf(value);
-            if (Objects.equals(p.belowNameData.value.getTemporaryValue(), newValue)) return;
-            p.belowNameData.value.setTemporaryValue(newValue);
-            p.belowNameData.fancyValue.setTemporaryValue(newValue);
+            if (Objects.equals(p.belowNameData.value.getTemporaryValue(), value)) return;
+            p.belowNameData.value.setTemporaryValue(value);
             refresh(p, true);
         }, getFeatureName(), "Processing API call (setValue)"));
+    }
+
+    @Override
+    @Nullable
+    public String getCustomValue(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        return ((TabPlayer) player).belowNameData.value.getTemporaryValue();
+    }
+
+    @Override
+    public void setFancyValue(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable String fancyValue) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            if (Objects.equals(p.belowNameData.fancyValue.getTemporaryValue(), fancyValue)) return;
+            p.belowNameData.fancyValue.setTemporaryValue(fancyValue);
+            refresh(p, true);
+        }, getFeatureName(), "Processing API call (setFancyValue)"));
+    }
+
+    @Override
+    @Nullable
+    public String getCustomFancyValue(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        return ((TabPlayer) player).belowNameData.fancyValue.getTemporaryValue();
     }
 
     @Override
@@ -389,19 +408,10 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
     }
 
     @Override
-    public void reset(@NonNull me.neznamy.tab.api.TabPlayer player) {
+    @Nullable
+    public String getCustomTitle(@NonNull me.neznamy.tab.api.TabPlayer player) {
         ensureActive();
-        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
-            TabPlayer p = (TabPlayer) player;
-            p.ensureLoaded();
-            p.belowNameData.forcedEnabled = null;
-            p.belowNameData.value.setTemporaryValue(null);
-            p.belowNameData.fancyValue.setTemporaryValue(null);
-            p.belowNameData.title.setTemporaryValue(null);
-            applyDisabledState(p, configuredDisabled(p));
-            if (!p.belowNameData.disabled.get()) updateObjective(p);
-            refresh(p, true);
-        }, getFeatureName(), "Processing API call (reset)"));
+        return ((TabPlayer) player).belowNameData.title.getTemporaryValue();
     }
 
     @Override

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowName.java
@@ -1,6 +1,8 @@
 package me.neznamy.tab.shared.features.belowname;
 
 import lombok.Getter;
+import lombok.NonNull;
+import me.neznamy.tab.api.belowname.BelowNameManager;
 import me.neznamy.tab.shared.Property;
 import me.neznamy.tab.shared.ProtocolVersion;
 import me.neznamy.tab.shared.TAB;
@@ -28,7 +30,7 @@ import java.util.stream.Collectors;
  */
 @Getter
 public class BelowName extends RefreshableFeature implements JoinListener, QuitListener, Loadable, UnLoadable,
-        WorldSwitchListener, ServerSwitchListener, CustomThreaded, ProxyFeature, VanishListener, Dumpable {
+        WorldSwitchListener, ServerSwitchListener, CustomThreaded, ProxyFeature, VanishListener, Dumpable, BelowNameManager {
 
     /** Objective name used by this feature */
     public static final String OBJECTIVE_NAME = "TAB-BelowName";
@@ -70,7 +72,7 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
         for (TabPlayer loaded : onlinePlayers.getPlayers()) {
             loaded.setBelowNameDistance(configuration.getViewDistance());
             loadProperties(loaded);
-            if (disableChecker.isDisableConditionMet(loaded)) {
+            if (configuredDisabled(loaded)) {
                 loaded.belowNameData.disabled.set(true);
             } else {
                 register(loaded);
@@ -104,7 +106,7 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
         onlinePlayers.addPlayer(connectedPlayer);
         connectedPlayer.setBelowNameDistance(configuration.getViewDistance());
         loadProperties(connectedPlayer);
-        if (disableChecker.isDisableConditionMet(connectedPlayer)) {
+        if (configuredDisabled(connectedPlayer)) {
             connectedPlayer.belowNameData.disabled.set(true);
         } else {
             register(connectedPlayer);
@@ -143,6 +145,28 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
      *          Whether the feature is disabled now or not
      */
     public void onDisableConditionChange(TabPlayer p, boolean disabledNow) {
+        Boolean forced = p.belowNameData.forcedEnabled;
+        if (forced != null) {
+            p.belowNameData.disabled.set(!forced);
+            return;
+        }
+        if (!configuration.isEnabled()) {
+            p.belowNameData.disabled.set(true);
+            return;
+        }
+        updateVisibility(p, disabledNow);
+    }
+
+    private boolean configuredDisabled(@NotNull TabPlayer p) {
+        return !configuration.isEnabled() || disableChecker.isDisableConditionMet(p);
+    }
+
+    private void applyDisabledState(@NotNull TabPlayer p, boolean disabled) {
+        if (p.belowNameData.disabled.getAndSet(disabled) == disabled) return;
+        updateVisibility(p, disabled);
+    }
+
+    private void updateVisibility(@NotNull TabPlayer p, boolean disabledNow) {
         if (disabledNow) {
             p.getScoreboard().unregisterObjective(OBJECTIVE_NAME);
         } else {
@@ -220,6 +244,15 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
         player.getScoreboard().setDisplaySlot(OBJECTIVE_NAME, Scoreboard.DisplaySlot.BELOW_NAME);
     }
 
+    private void updateObjective(@NotNull TabPlayer player) {
+        player.getScoreboard().updateObjective(
+                OBJECTIVE_NAME,
+                cache.get(player.belowNameData.title.updateAndGet()),
+                Scoreboard.HealthDisplay.INTEGER,
+                cache.get(player.belowNameData.defaultNumberFormat.updateAndGet())
+        );
+    }
+
     /**
      * Updates score of specified entry to player.
      *
@@ -235,6 +268,10 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
     public void setScore(@NotNull TabPlayer viewer, @NotNull TabPlayer scoreHolder, int value, @NotNull String fancyValue) {
         if (viewer.belowNameData.disabled.get()) return;
         if (viewer.server != scoreHolder.server || viewer.world != scoreHolder.world) return; // Viewer definitely cannot see this player in game
+        if (Boolean.FALSE.equals(scoreHolder.belowNameData.forcedEnabled)) {
+            viewer.getScoreboard().removeScore(OBJECTIVE_NAME, scoreHolder.getNickname());
+            return;
+        }
         if (viewer.canSee(scoreHolder)) {
             if (fancyValue.isEmpty() && viewer.getVersionId() >= ProtocolVersion.V26_2.getNetworkId()) {
                 viewer.getScoreboard().removeScore(OBJECTIVE_NAME, scoreHolder.getNickname());
@@ -300,6 +337,71 @@ public class BelowName extends RefreshableFeature implements JoinListener, QuitL
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
             setScore(viewer, player, getValue(player), player.belowNameData.fancyValue.getFormat(viewer));
         }
+    }
+
+    // ------------------
+    // API Implementation
+    // ------------------
+
+    @Override
+    public void setEnabled(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable Boolean enabled) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            p.belowNameData.forcedEnabled = enabled;
+            applyDisabledState(p, enabled == null ? configuredDisabled(p) : !enabled);
+            refresh(p, true);
+        }, getFeatureName(), "Processing API call (setEnabled)"));
+    }
+
+    @Override
+    @Nullable
+    public Boolean getCustomEnabled(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        return ((TabPlayer) player).belowNameData.forcedEnabled;
+    }
+
+    @Override
+    public void setValue(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable Integer value) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            String newValue = value == null ? null : String.valueOf(value);
+            if (Objects.equals(p.belowNameData.value.getTemporaryValue(), newValue)) return;
+            p.belowNameData.value.setTemporaryValue(newValue);
+            p.belowNameData.fancyValue.setTemporaryValue(newValue);
+            refresh(p, true);
+        }, getFeatureName(), "Processing API call (setValue)"));
+    }
+
+    @Override
+    public void setTitle(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable String title) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            if (Objects.equals(p.belowNameData.title.getTemporaryValue(), title)) return;
+            p.belowNameData.title.setTemporaryValue(title);
+            if (!p.belowNameData.disabled.get()) updateObjective(p);
+        }, getFeatureName(), "Processing API call (setTitle)"));
+    }
+
+    @Override
+    public void reset(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            p.belowNameData.forcedEnabled = null;
+            p.belowNameData.value.setTemporaryValue(null);
+            p.belowNameData.fancyValue.setTemporaryValue(null);
+            p.belowNameData.title.setTemporaryValue(null);
+            applyDisabledState(p, configuredDisabled(p));
+            if (!p.belowNameData.disabled.get()) updateObjective(p);
+            refresh(p, true);
+        }, getFeatureName(), "Processing API call (reset)"));
     }
 
     @Override

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowNameConfiguration.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowNameConfiguration.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 public class BelowNameConfiguration {
 
     @NotNull private final ConfigurationSection section;
+    private final boolean enabled;
     @NotNull private final String value;
     @NotNull private final String title;
     @NotNull private final String fancyValue;
@@ -70,6 +71,7 @@ public class BelowNameConfiguration {
 
         return new BelowNameConfiguration(
                 section,
+                section.getBoolean("enabled", false),
                 value,
                 title,
                 section.getString("fancy-value", "&c" + TabConstants.Placeholder.HEALTH),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowNamePlayerData.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/belowname/BelowNamePlayerData.java
@@ -1,6 +1,7 @@
 package me.neznamy.tab.shared.features.belowname;
 
 import me.neznamy.tab.shared.Property;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -23,4 +24,7 @@ public class BelowNamePlayerData {
 
     /** Flag tracking whether this feature is disabled for the player with condition or not */
     public final AtomicBoolean disabled = new AtomicBoolean();
+
+    /** Visibility forced using the API, {@code null} if not forced */
+    @Nullable public volatile Boolean forcedEnabled;
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/PlayerListObjectiveConfiguration.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/PlayerListObjectiveConfiguration.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 public class PlayerListObjectiveConfiguration {
 
     @NotNull private final ConfigurationSection section;
+    private final boolean enabled;
     @NotNull private final String value;
     @NotNull private final String fancyValue;
     @NotNull private final String title;
@@ -71,6 +72,7 @@ public class PlayerListObjectiveConfiguration {
 
         return new PlayerListObjectiveConfiguration(
                 section,
+                section.getBoolean("enabled", true),
                 value,
                 section.getString("fancy-value", "&7Ping: " + Placeholder.PING),
                 section.getString("title", "TAB"),

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/PlayerListObjectivePlayerData.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/PlayerListObjectivePlayerData.java
@@ -1,6 +1,8 @@
 package me.neznamy.tab.shared.features.playerlistobjective;
 
+import me.neznamy.tab.api.playerlistobjective.PlayerListObjectiveManager.RenderType;
 import me.neznamy.tab.shared.Property;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -20,4 +22,10 @@ public class PlayerListObjectivePlayerData {
 
     /** Flag tracking whether this feature is disabled for the player with condition or not */
     public final AtomicBoolean disabled = new AtomicBoolean();
+
+    /** Visibility forced using the API, {@code null} if not forced */
+    @Nullable public volatile Boolean forcedEnabled;
+
+    /** Render type forced using the API, {@code null} if not forced */
+    @Nullable public volatile RenderType forcedRenderType;
 }

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
@@ -1,6 +1,8 @@
 package me.neznamy.tab.shared.features.playerlistobjective;
 
 import lombok.Getter;
+import lombok.NonNull;
+import me.neznamy.tab.api.playerlistobjective.PlayerListObjectiveManager;
 import me.neznamy.tab.shared.Property;
 import me.neznamy.tab.shared.TAB;
 import me.neznamy.tab.shared.TabConstants;
@@ -26,7 +28,7 @@ import java.util.stream.Collectors;
  */
 @Getter
 public class YellowNumber extends RefreshableFeature implements JoinListener, QuitListener, Loadable,
-        CustomThreaded, ProxyFeature, VanishListener, Dumpable {
+        CustomThreaded, ProxyFeature, VanishListener, Dumpable, PlayerListObjectiveManager {
 
     /** Objective name used by this feature */
     public static final String OBJECTIVE_NAME = "TAB-PlayerList";
@@ -67,7 +69,7 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         Map<TabPlayer, Integer> values = new HashMap<>();
         for (TabPlayer loaded : onlinePlayers.getPlayers()) {
             loadProperties(loaded);
-            if (disableChecker.isDisableConditionMet(loaded)) {
+            if (configuredDisabled(loaded)) {
                 loaded.playerlistObjectiveData.disabled.set(true);
             } else {
                 register(loaded);
@@ -92,7 +94,7 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
     public void onJoin(@NotNull TabPlayer connectedPlayer) {
         onlinePlayers.addPlayer(connectedPlayer);
         loadProperties(connectedPlayer);
-        if (disableChecker.isDisableConditionMet(connectedPlayer)) {
+        if (configuredDisabled(connectedPlayer)) {
             connectedPlayer.playerlistObjectiveData.disabled.set(true);
         } else {
             register(connectedPlayer);
@@ -131,6 +133,28 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
      *          Whether the feature is disabled now or not
      */
     public void onDisableConditionChange(TabPlayer p, boolean disabledNow) {
+        Boolean forced = p.playerlistObjectiveData.forcedEnabled;
+        if (forced != null) {
+            p.playerlistObjectiveData.disabled.set(!forced);
+            return;
+        }
+        if (!configuration.isEnabled()) {
+            p.playerlistObjectiveData.disabled.set(true);
+            return;
+        }
+        updateVisibility(p, disabledNow);
+    }
+
+    private boolean configuredDisabled(@NotNull TabPlayer p) {
+        return !configuration.isEnabled() || disableChecker.isDisableConditionMet(p);
+    }
+
+    private void applyDisabledState(@NotNull TabPlayer p, boolean disabled) {
+        if (p.playerlistObjectiveData.disabled.getAndSet(disabled) == disabled) return;
+        updateVisibility(p, disabled);
+    }
+
+    private void updateVisibility(@NotNull TabPlayer p, boolean disabledNow) {
         if (disabledNow) {
             p.getScoreboard().unregisterObjective(OBJECTIVE_NAME);
         } else {
@@ -202,10 +226,25 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         player.getScoreboard().registerObjective(
                 OBJECTIVE_NAME,
                 cache.get(player.playerlistObjectiveData.title.updateAndGet()),
-                configuration.getHealthDisplay(),
+                getHealthDisplay(player),
                 TabComponent.empty()
         );
         player.getScoreboard().setDisplaySlot(OBJECTIVE_NAME, Scoreboard.DisplaySlot.PLAYER_LIST);
+    }
+
+    private void updateObjective(@NotNull TabPlayer player) {
+        player.getScoreboard().updateObjective(
+                OBJECTIVE_NAME,
+                cache.get(player.playerlistObjectiveData.title.updateAndGet()),
+                getHealthDisplay(player),
+                TabComponent.empty()
+        );
+    }
+
+    @NotNull
+    private Scoreboard.HealthDisplay getHealthDisplay(@NotNull TabPlayer player) {
+        RenderType forced = player.playerlistObjectiveData.forcedRenderType;
+        return forced == null ? configuration.getHealthDisplay() : Scoreboard.HealthDisplay.valueOf(forced.name());
     }
 
     /**
@@ -265,6 +304,83 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
         for (TabPlayer viewer : onlinePlayers.getPlayers()) {
             setScore(viewer, player, getValue(player), player.playerlistObjectiveData.fancyValue.getFormat(viewer));
         }
+    }
+
+    // ------------------
+    // API Implementation
+    // ------------------
+
+    @Override
+    public void setEnabled(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable Boolean enabled) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            p.playerlistObjectiveData.forcedEnabled = enabled;
+            applyDisabledState(p, enabled == null ? configuredDisabled(p) : !enabled);
+        }, getFeatureName(), "Processing API call (setEnabled)"));
+    }
+
+    @Override
+    @Nullable
+    public Boolean getCustomEnabled(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        return ((TabPlayer) player).playerlistObjectiveData.forcedEnabled;
+    }
+
+    @Override
+    public void setValue(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable Integer value) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            String newValue = value == null ? null : String.valueOf(value);
+            if (Objects.equals(p.playerlistObjectiveData.value.getTemporaryValue(), newValue)) return;
+            p.playerlistObjectiveData.value.setTemporaryValue(newValue);
+            p.playerlistObjectiveData.fancyValue.setTemporaryValue(newValue);
+            refresh(p, true);
+        }, getFeatureName(), "Processing API call (setValue)"));
+    }
+
+    @Override
+    public void setTitle(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable String title) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            if (Objects.equals(p.playerlistObjectiveData.title.getTemporaryValue(), title)) return;
+            p.playerlistObjectiveData.title.setTemporaryValue(title);
+            if (!p.playerlistObjectiveData.disabled.get()) updateObjective(p);
+        }, getFeatureName(), "Processing API call (setTitle)"));
+    }
+
+    @Override
+    public void setRenderType(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable RenderType renderType) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            if (p.playerlistObjectiveData.forcedRenderType == renderType) return;
+            p.playerlistObjectiveData.forcedRenderType = renderType;
+            if (!p.playerlistObjectiveData.disabled.get()) updateObjective(p);
+        }, getFeatureName(), "Processing API call (setRenderType)"));
+    }
+
+    @Override
+    public void reset(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            p.playerlistObjectiveData.forcedEnabled = null;
+            p.playerlistObjectiveData.forcedRenderType = null;
+            p.playerlistObjectiveData.value.setTemporaryValue(null);
+            p.playerlistObjectiveData.fancyValue.setTemporaryValue(null);
+            p.playerlistObjectiveData.title.setTemporaryValue(null);
+            applyDisabledState(p, configuredDisabled(p));
+            if (!p.playerlistObjectiveData.disabled.get()) updateObjective(p);
+            refresh(p, true);
+        }, getFeatureName(), "Processing API call (reset)"));
     }
 
     @Override

--- a/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
+++ b/shared/src/main/java/me/neznamy/tab/shared/features/playerlistobjective/YellowNumber.java
@@ -329,17 +329,41 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
     }
 
     @Override
-    public void setValue(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable Integer value) {
+    public void setValue(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable String value) {
         ensureActive();
         customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
             TabPlayer p = (TabPlayer) player;
             p.ensureLoaded();
-            String newValue = value == null ? null : String.valueOf(value);
-            if (Objects.equals(p.playerlistObjectiveData.value.getTemporaryValue(), newValue)) return;
-            p.playerlistObjectiveData.value.setTemporaryValue(newValue);
-            p.playerlistObjectiveData.fancyValue.setTemporaryValue(newValue);
+            if (Objects.equals(p.playerlistObjectiveData.value.getTemporaryValue(), value)) return;
+            p.playerlistObjectiveData.value.setTemporaryValue(value);
             refresh(p, true);
         }, getFeatureName(), "Processing API call (setValue)"));
+    }
+
+    @Override
+    @Nullable
+    public String getCustomValue(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        return ((TabPlayer) player).playerlistObjectiveData.value.getTemporaryValue();
+    }
+
+    @Override
+    public void setFancyValue(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable String fancyValue) {
+        ensureActive();
+        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
+            TabPlayer p = (TabPlayer) player;
+            p.ensureLoaded();
+            if (Objects.equals(p.playerlistObjectiveData.fancyValue.getTemporaryValue(), fancyValue)) return;
+            p.playerlistObjectiveData.fancyValue.setTemporaryValue(fancyValue);
+            refresh(p, true);
+        }, getFeatureName(), "Processing API call (setFancyValue)"));
+    }
+
+    @Override
+    @Nullable
+    public String getCustomFancyValue(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        return ((TabPlayer) player).playerlistObjectiveData.fancyValue.getTemporaryValue();
     }
 
     @Override
@@ -355,6 +379,13 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
     }
 
     @Override
+    @Nullable
+    public String getCustomTitle(@NonNull me.neznamy.tab.api.TabPlayer player) {
+        ensureActive();
+        return ((TabPlayer) player).playerlistObjectiveData.title.getTemporaryValue();
+    }
+
+    @Override
     public void setRenderType(@NonNull me.neznamy.tab.api.TabPlayer player, @Nullable RenderType renderType) {
         ensureActive();
         customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
@@ -367,20 +398,10 @@ public class YellowNumber extends RefreshableFeature implements JoinListener, Qu
     }
 
     @Override
-    public void reset(@NonNull me.neznamy.tab.api.TabPlayer player) {
+    @Nullable
+    public RenderType getCustomRenderType(@NonNull me.neznamy.tab.api.TabPlayer player) {
         ensureActive();
-        customThread.execute(new TimedCaughtTask(TAB.getInstance().getCpu(), () -> {
-            TabPlayer p = (TabPlayer) player;
-            p.ensureLoaded();
-            p.playerlistObjectiveData.forcedEnabled = null;
-            p.playerlistObjectiveData.forcedRenderType = null;
-            p.playerlistObjectiveData.value.setTemporaryValue(null);
-            p.playerlistObjectiveData.fancyValue.setTemporaryValue(null);
-            p.playerlistObjectiveData.title.setTemporaryValue(null);
-            applyDisabledState(p, configuredDisabled(p));
-            if (!p.playerlistObjectiveData.disabled.get()) updateObjective(p);
-            refresh(p, true);
-        }, getFeatureName(), "Processing API call (reset)"));
+        return ((TabPlayer) player).playerlistObjectiveData.forcedRenderType;
     }
 
     @Override


### PR DESCRIPTION
Adds BelowNameManager and PlayerListObjectiveManager, exposing per-player control over the belowname and playerlist objectives: forced enable/disable, title, value, and (playerlist only) render type, plus reset().